### PR TITLE
Next.js를 위한 styled component 설정

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": ["@babel/plugin-proposal-do-expressions"]
+  "plugins": ["@babel/plugin-proposal-do-expressions", "babel-plugin-styled-components"]
 }

--- a/frontend/src/components/FloatingButton/index.tsx
+++ b/frontend/src/components/FloatingButton/index.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react';
+
+import FloatingButton from './style';
+
+function Header(): ReactElement {
+  return <FloatingButton>test</FloatingButton>;
+}
+
+export default Header;

--- a/frontend/src/components/FloatingButton/style.ts
+++ b/frontend/src/components/FloatingButton/style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const FloatingButton = styled.button`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  margin: 48px;
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+`;
+
+export default FloatingButton;

--- a/frontend/src/components/UsersRecommendation/index.tsx
+++ b/frontend/src/components/UsersRecommendation/index.tsx
@@ -1,0 +1,15 @@
+import { ReactElement } from 'react';
+
+import styled from 'styled-components';
+
+const Card = styled.div`
+  display: flex;
+  box-shadow: 2px 2px 2px 1px #000000;
+  height: 480px;
+`;
+
+function UsersRecommendation(): ReactElement {
+  return <Card>header</Card>;
+}
+
+export default UsersRecommendation;

--- a/frontend/src/components/UsersRecommendation/style.ts
+++ b/frontend/src/components/UsersRecommendation/style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const Card = styled.div`
+  display: flex;
+  box-shadow: 2px 2px 2px 1px #000000;
+  height: 480px;
+`;
+
+export default Card;

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,0 +1,51 @@
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+} from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+import { ReactElement } from 'react';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render(): ReactElement {
+    return (
+      <Html lang='en'>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+export default MyDocument;

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,6 +1,9 @@
 import type { ReactElement } from 'react';
 import Head from 'next/head';
 
+import UsersRecommendation from 'src/components/UsersRecommendation';
+import FloatingButton from 'src/components/FloatingButton';
+
 function Home(): ReactElement {
   return (
     <div>
@@ -13,8 +16,9 @@ function Home(): ReactElement {
         <link rel='icon' href='/favicon.ico' />
       </Head>
 
-      <main>Home/</main>
+      <UsersRecommendation />
 
+      <FloatingButton />
       <footer />
     </div>
   );


### PR DESCRIPTION
### 제목
.babelrc 에다가 플러그인 넣는 식으로 설정 했습니다.
공식 문서 보고 했으니까 불안해하지 마십쇼.

### 파일 변경
- .babelrc: 스타일드 컴포넌트 플러그인 추가
- frontend/src/components/FloatingButton/index.tsx: 플로핑 버튼 컴포넌트 프로토타입
- frontend/src/components/FloatingButton/style.ts: 플로팅 버튼 스타일드 컴포넌트
- frontend/src/components/UsersRecommendation/index.tsx: 초기 유입 페이지 유저 추천 레이아웃 프로토타입
- frontend/src/pages/_document.tsx: next.js 에 styled_component 설정 (클래스형 컴포넌트 사용한 이유는 상속을 받기 위해서임)
- frontend/src/pages/home.tsx: 컴포넌트 프로토타입 만든 것 사용