### PR TITLE
users api 추가 구현

### DIFF
--- a/backend/src/loaders/passportLoader.ts
+++ b/backend/src/loaders/passportLoader.ts
@@ -17,10 +17,22 @@ export default function passportLoader(app: express.Application): void {
     secretOrKey: process.env.JWT_ACCESS_SECRET,
   };
 
-  const verifyUser = async (jwtPayload: any, done: VerifiedCallback) => {
+  const verifyRegisteredUser = async (jwtPayload: any, done: VerifiedCallback) => {
     try {
       const user: User = { userID: jwtPayload.userID! };
       if (!user || !(await UserService.existsRegisteredUser(user))) {
+        return done(null, false);
+      }
+      return done(null, user);
+    } catch (error) {
+      return done(error, false);
+    }
+  };
+
+  const verifyUser = async (jwtPayload: any, done: VerifiedCallback) => {
+    try {
+      const user: User = { userID: jwtPayload.userID! };
+      if (!user || !(await UserService.existsUser(user))) {
         return done(null, false);
       }
       return done(null, user);
@@ -48,6 +60,7 @@ export default function passportLoader(app: express.Application): void {
     done(null, user);
   };
 
+  passport.use('jwt-registered', new JWTStrategy(jwtStrategyOptions, verifyRegisteredUser));
   passport.use('jwt', new JWTStrategy(jwtStrategyOptions, verifyUser));
   passport.use('google', new GoogleStrategy(googleStrategyOptions, verifyGoogleUser));
   app.use(passport.initialize());

--- a/backend/src/routers/v1/socials.ts
+++ b/backend/src/routers/v1/socials.ts
@@ -21,7 +21,7 @@ export default class PostsRouter {
   getGoogleCallback(@Req() request: Request, @Res() response: Response) {
     const accessToken = JWT.createAccessToken(request.user!);
     response.cookie('jwt', accessToken, {
-      maxAge: Number(process.env.JWT_ACCESS_EXPIRE_IN!),
+      maxAge: Number(process.env.JWT_ACCESS_EXPIRE_IN!) * 1000,
       httpOnly: true,
     });
   }

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -24,7 +24,7 @@ export default class UsersRouter {
   }
 
   @Put('/:userID')
-  @UseBefore(passport.authenticate('jwt', { session: false }))
+  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
   async putUser(@Req() request: Request, @Res() response: Response) {
     const { userID } = request.params;
     if (userID !== request.user!.userID) throw new Error('잘못된 형식의 Path Params 입니다.');

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { Controller, Req, Res, Get, Post, UseBefore } from 'routing-controllers';
 import * as passport from 'passport';
+
 import { UserService } from 'src/services';
 
 @Controller('/users')
@@ -9,7 +10,10 @@ export default class UsersRouter {
   async getUsersValidUsername(@Req() request: Request, @Res() response: Response) {
     const { username } = request.query;
     if (!username) throw new Error('잘못된 형식의 Query 입니다.');
-    return response.json({});
+    const isExistUsername = await UserService.existsUserForUsername({
+      username: username as string,
+    });
+    return response.json({ isExistUsername });
   }
 
   @Get('/me')

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { Controller, Req, Res, Get, Post, UseBefore } from 'routing-controllers';
+import { Controller, Req, Res, Get, Put, UseBefore } from 'routing-controllers';
 import * as passport from 'passport';
 
 import { UserService } from 'src/services';
@@ -19,12 +19,16 @@ export default class UsersRouter {
   @Get('/me')
   @UseBefore(passport.authenticate('jwt', { session: false }))
   async getUsersMe(@Req() request: Request, @Res() response: Response) {
-    const user = await UserService.findOneUserForID({ userID: request.user!.id });
+    const user = await UserService.findOneUserForID({ userID: request.user!.userID });
     return response.json({ user });
   }
 
-  @Post('/test')
-  getAllPosts(@Req() request: Request, @Res() response: Response) {
+  @Put('/:userID')
+  @UseBefore(passport.authenticate('jwt', { session: false }))
+  async putUser(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    if (userID !== request.user!.userID) throw new Error('잘못된 형식의 Path Params 입니다.');
+    await UserService.updateOneUserConfig({ userID: request.user!.userID }, request.body);
     return response.send('Test!');
   }
 }

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -2,6 +2,12 @@ import { nanoid } from 'nanoid';
 
 import { User } from 'src/models';
 import { User as UserType, UserAuthProvider } from 'src/types';
+import { UserType as UserSchemaType } from 'src/types/modelType';
+import { Types } from 'mongoose';
+
+interface UserConfigType extends Omit<UserSchemaType, 'languages'> {
+  languages: string[];
+}
 
 class UserService {
   static async existsRegisteredUser(user: UserType): Promise<boolean> {
@@ -39,6 +45,14 @@ class UserService {
   static async findOneUserForID(user: UserType) {
     const result = await User.findOne(user).select({ _id: true });
     return result;
+  }
+
+  static async updateOneUserConfig<Type extends UserConfigType>(user: UserType, userConfig: Type) {
+    const userConfigSchema: UserSchemaType = { ...userConfig, languages: [] };
+    userConfigSchema.languages = userConfig.languages?.map((language) => ({
+      languageID: new Types.ObjectId(language),
+    }));
+    await User.updateOne({ _id: user.userID }, userConfigSchema);
   }
 }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -48,7 +48,13 @@ class UserService {
   }
 
   static async findOneUserForID(user: UserType) {
-    const result = await User.findOne(user).select({ _id: true, isRegistered: true });
+    const result = await User.findOne(user).select({
+      _id: true,
+      isRegistered: true,
+      profileImage: true,
+      username: true,
+      name: true,
+    });
     return result;
   }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -10,6 +10,11 @@ interface UserConfigType extends Omit<UserSchemaType, 'languages'> {
 }
 
 class UserService {
+  static async existsUser(user: UserType): Promise<boolean> {
+    const result = await User.exists(user);
+    return result;
+  }
+
   static async existsRegisteredUser(user: UserType): Promise<boolean> {
     const result = await User.findOne(user).select({
       isRegistered: true,
@@ -43,7 +48,7 @@ class UserService {
   }
 
   static async findOneUserForID(user: UserType) {
-    const result = await User.findOne(user).select({ _id: true });
+    const result = await User.findOne(user).select({ _id: true, isRegistered: true });
     return result;
   }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -12,6 +12,11 @@ class UserService {
     return result.isRegistered!;
   }
 
+  static async existsUserForUsername(user: { username: string }): Promise<boolean> {
+    const result = await User.exists({ username: user.username });
+    return result;
+  }
+
   static async findOneUserForProvider(
     userAuthProvider: UserAuthProvider,
   ): Promise<UserType | undefined> {

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -3,7 +3,7 @@ export {};
 declare global {
   namespace Express {
     interface User {
-      id: string;
+      userID: string;
     }
   }
 }

--- a/backend/src/types/modelType.ts
+++ b/backend/src/types/modelType.ts
@@ -1,15 +1,15 @@
-import { Schema } from 'mongoose';
+import { Types } from 'mongoose';
 
 export interface LanguageIDType {
-  languageID: Schema.Types.ObjectId;
+  languageID: Types.ObjectId;
 }
 
 export interface PostIDType {
-  postID: Schema.Types.ObjectId;
+  postID: Types.ObjectId;
 }
 
 export interface UserIDType {
-  userID: Schema.Types.ObjectId;
+  userID: Types.ObjectId;
 }
 
 export interface NotifyRangeType {
@@ -64,17 +64,17 @@ export interface CommentType extends UserIDType {
 export interface PostType {
   title?: string;
   content?: string;
-  userID?: Schema.Types.ObjectId;
+  userID?: Types.ObjectId;
   image?: string;
   comments?: CommentType[];
   likes?: UserIDType[];
-  tags?: Schema.Types.ObjectId[];
+  tags?: Types.ObjectId[];
   versionKey?: boolean;
 }
 
 export interface EchoRoomType {
-  users: Schema.Types.ObjectId[];
-  messages: { userID: Schema.Types.ObjectId; content: string; createdAt: Date }[];
+  users: Types.ObjectId[];
+  messages: { userID: Types.ObjectId; content: string; createdAt: Date }[];
 }
 
 export interface TagType {

--- a/backend/src/utils/ObjectID.ts
+++ b/backend/src/utils/ObjectID.ts
@@ -1,0 +1,5 @@
+class ObjectID {
+  static stringToObjectID() {}
+
+  static objectIDToString() {}
+}


### PR DESCRIPTION
### 제목
users api 추가 구현

### 파일 변경
- backend/src/loaders/passportLoader.ts: passport jwt 정책 2가지로 분리
- backend/src/routers/v1/socials.ts: maxAge 시간 90일로 변경
- backend/src/routers/v1/users.ts: username 유효성 검사, 유저 입력 데이터 저장 api 추가
- backend/src/services/UserService.ts: user collection service 메소드 추가
- backend/src/types/express/index.d.ts: Express User Type 일관성 있게 변경
- backend/src/types/modelType.ts: Schema.Types -> Types
- backend/src/utils/ObjectID.ts: 추후 업데이트