### PR TITLE
이미지 API 변경으로 인한 이미지 타입 생성 및 적용

### DIFF
--- a/frontend/src/components/PostImages/index.tsx
+++ b/frontend/src/components/PostImages/index.tsx
@@ -7,10 +7,12 @@ import RightSlideButton from 'src/components/buttons/slides/RightSlideButton';
 
 import { POST_IMAGE_WIDTH, POST_IMAGE_HEIGHT } from 'src/globals/constants';
 
+import { ImageType } from 'src/types';
+
 import { Wrapper, ImageHolder, SlideButtons } from './style';
 
 interface Props {
-  images: string[];
+  images: ImageType[];
 }
 
 function PostImages({ images }: Props) {
@@ -29,8 +31,8 @@ function PostImages({ images }: Props) {
     <Wrapper>
       <ImageHolder ref={imageHolderRef} count={images.length}>
         {images.map((image) => (
-          <li key={image}>
-            <Image src={image} width={POST_IMAGE_WIDTH} height={POST_IMAGE_HEIGHT} />
+          <li key={image._id}>
+            <Image src={image.url} width={POST_IMAGE_WIDTH} height={POST_IMAGE_HEIGHT} />
           </li>
         ))}
       </ImageHolder>
@@ -43,7 +45,7 @@ function PostImages({ images }: Props) {
 }
 
 PostImages.propTypes = {
-  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+  images: PropTypes.arrayOf(PropTypes.any).isRequired,
 };
 
 export default PostImages;

--- a/frontend/src/types/image.ts
+++ b/frontend/src/types/image.ts
@@ -1,0 +1,4 @@
+export default interface imageType {
+  _id: string;
+  url: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,5 +3,6 @@ import PostType from './post';
 import LikeType from './like';
 import ThemeType from './theme';
 import CommentType from './comment';
+import ImageType from './image';
 
-export type { UserType, PostType, LikeType, ThemeType, CommentType };
+export type { UserType, PostType, LikeType, ThemeType, CommentType, ImageType };


### PR DESCRIPTION
### 제목
이미지 API 변경으로 인한 이미지 타입 생성 및 적용

### 파일 변경
- frontend/src/components/PostImages/index.tsx: PostImage 컴포넌트에 변경된 이미지 타입 적용
- frontend/src/types/image.ts: 이미지 타입 생성
- frontend/src/types/index.ts: 이미지 타입 모듈화
