### PR TITLE
이미지 프리뷰 컴포넌트 버그 잡기

### DIFF
--- a/frontend/src/components/ImagesPreview/style.ts
+++ b/frontend/src/components/ImagesPreview/style.ts
@@ -1,6 +1,12 @@
 import styled from '@emotion/styled';
 
+import { Col } from 'src/components/Grid';
+
 const Wrapper = styled.div`
+  ${Col} {
+    width: 120px;
+    margin: 0 4px;
+  }
   img {
     border-radius: 24px;
   }

--- a/frontend/src/components/buttons/FollowButton/index.tsx
+++ b/frontend/src/components/buttons/FollowButton/index.tsx
@@ -10,7 +10,7 @@ import userAtom from 'src/recoil/user';
 
 interface Props {
   targetUserID: string;
-  isFollower: boolean;
+  isFollower?: boolean;
 }
 
 function FollowButton({ targetUserID, isFollower }: Props) {
@@ -24,7 +24,11 @@ function FollowButton({ targetUserID, isFollower }: Props) {
 
 FollowButton.propTypes = {
   targetUserID: PropTypes.string.isRequired,
-  isFollower: PropTypes.bool.isRequired,
+  isFollower: PropTypes.bool,
+};
+
+FollowButton.defaultProps = {
+  isFollower: false,
 };
 
 export default FollowButton;

--- a/frontend/src/components/inputs/ImageInput/index.tsx
+++ b/frontend/src/components/inputs/ImageInput/index.tsx
@@ -14,6 +14,8 @@ interface Props {
 function ImageInput({ onImageUpload, children }: Props) {
   const handleOnChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files!);
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = '';
     const requests = files.map((file) => Uploader.uploadPostImage(file));
     const responses = await Promise.all(requests);
     responses.forEach((url) => onImageUpload(url));


### PR DESCRIPTION
### 제목
- ImagePreview 스타일 수정
- ImagePreview 같은 이미지 연속으로 등록 가능
- FollowButton props isRequired 수정 (🥲)

### 파일 변경
- frontend/src/components/ImagesPreview/style.ts: 이미지 프리뷰 스타일 수정 (이미지 가로로 째지던 버그 수정)
- frontend/src/components/buttons/FollowButton/index.tsx: 팔로우 버튼 Props isRequired 수정
- frontend/src/components/inputs/ImageInput/index.tsx: image 중복 업로드 가능하도록 업로드 즉시 flush
