### PR TITLE
Follow Unfollow 버튼을 FollowSet으로 묶고 추상화

### DIFF
--- a/frontend/src/components/cards/UserInfoCard/index.tsx
+++ b/frontend/src/components/cards/UserInfoCard/index.tsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 import { IoSettingsOutline } from 'react-icons/io5';
 
 import CardCommon from 'src/components/cards/Common';
-import FollowButton from 'src/components/buttons/FollowButton';
-import UnfollowButton from 'src/components/buttons/UnfollowButton';
 import NavigateIconButton from 'src/components/buttons/NavigateIconButton';
 import ProfileImage from 'src/components/images/ProfileImage';
+import FollowSet from 'src/components/sets/FollowSet';
 import { Row, Col } from 'src/components/Grid';
 
 import { UserType } from 'src/types';
@@ -27,20 +26,15 @@ interface Props {
 function UserInfoCard({ targetUser, user }: Props) {
   const { profileImage, username, postCount, followCount, name, bio } = targetUser;
   const [followerCount, setFollowerCount] = useState(targetUser.followerCount ?? 0);
-  const [isFollow, setIsFollow] = useState(user.follows?.includes(targetUser._id!));
+
+  const isMe = useMemo(() => targetUser._id === user._id, [targetUser._id, user._id]);
+
   const handleFollow = useCallback(() => {
     setFollowerCount((prevState) => prevState + 1);
-    setIsFollow(true);
   }, []);
   const handleUnfollow = useCallback(() => {
     setFollowerCount((prevState) => prevState - 1);
-    setIsFollow(false);
   }, []);
-  const isMe = useMemo(() => targetUser._id === user._id, [targetUser._id, user._id]);
-  const isFollower = useMemo(
-    () => user.followers?.includes(targetUser._id!),
-    [targetUser._id, user.followers],
-  );
 
   return (
     <Wrapper>
@@ -60,20 +54,11 @@ function UserInfoCard({ targetUser, user }: Props) {
                   <IoSettingsOutline />
                 </NavigateIconButton>
               ) : (
-                (() => {
-                  if (isFollow) {
-                    return (
-                      <UnfollowButton targetUserID={targetUser._id!} onUnfollow={handleUnfollow} />
-                    );
-                  }
-                  return (
-                    <FollowButton
-                      isFollower={isFollower!}
-                      targetUserID={targetUser._id!}
-                      onFollow={handleFollow}
-                    />
-                  );
-                })()
+                <FollowSet
+                  targetUser={targetUser}
+                  onFollow={handleFollow}
+                  onUnfollow={handleUnfollow}
+                />
               )}
             </Row>
             <Row>

--- a/frontend/src/components/sets/FollowSet/index.tsx
+++ b/frontend/src/components/sets/FollowSet/index.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import PropTypes from 'prop-types';
+
+import UnfollowButton from 'src/components/buttons/UnfollowButton';
+import FollowButton from 'src/components/buttons/FollowButton';
+
+import userAtom, { followersSelector, followsSelector } from 'src/recoil/user';
+
+import { UserType } from 'src/types';
+
+interface Props {
+  targetUser: UserType;
+  onFollow: () => void;
+  onUnfollow: () => void;
+}
+
+function FollowSet({ targetUser, onFollow, onUnfollow }: Props) {
+  const user = useRecoilValue(userAtom);
+  const followers = useRecoilValue(followersSelector);
+  const [follows, setFollows] = useRecoilState(followsSelector);
+
+  const isMe = useMemo(() => targetUser._id === user._id, [targetUser._id, user._id]);
+  const isFollower = useMemo(
+    () => followers?.includes(targetUser._id!),
+    [targetUser._id, followers],
+  );
+  const isFollow = useMemo(() => follows?.includes(targetUser._id!), [targetUser._id, follows]);
+
+  const handleFollow = useCallback(() => {
+    setFollows((prevState) => [...prevState, targetUser._id!]);
+    onFollow();
+  }, [onFollow, setFollows, targetUser._id]);
+
+  const handleUnfollow = useCallback(() => {
+    setFollows((prevState) => prevState.filter((id) => id !== targetUser._id));
+    onUnfollow();
+  }, [onUnfollow, setFollows, targetUser._id]);
+  if (isMe) {
+    return '';
+  }
+  return isFollow ? (
+    <UnfollowButton targetUserID={targetUser._id!} onUnfollow={handleUnfollow} />
+  ) : (
+    <FollowButton isFollower={isFollower!} targetUserID={targetUser._id!} onFollow={handleFollow} />
+  );
+}
+
+FollowSet.propTypes = {
+  targetUser: PropTypes.objectOf(PropTypes.any).isRequired,
+  onFollow: PropTypes.func,
+  onUnfollow: PropTypes.func,
+};
+
+FollowSet.defaultProps = {
+  onFollow: () => {},
+  onUnfollow: () => {},
+};
+
+export default FollowSet;

--- a/frontend/src/components/sets/FollowSet/index.tsx
+++ b/frontend/src/components/sets/FollowSet/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 function FollowSet({ targetUser, onFollow, onUnfollow }: Props) {
   const user = useRecoilValue(userAtom);
   const followers = useRecoilValue(followersSelector);
-  const [follows, setFollows] = useRecoilState(followsSelector);
+  const [follows, setFollows] = useRecoilState<string[]>(followsSelector);
 
   const isMe = useMemo(() => targetUser._id === user._id, [targetUser._id, user._id]);
   const isFollower = useMemo(

--- a/frontend/src/recoil/user/followers.ts
+++ b/frontend/src/recoil/user/followers.ts
@@ -1,0 +1,9 @@
+import { selector } from 'recoil';
+import userAtom from './atom';
+
+const followersSelector = selector<string[]>({
+  key: 'followersSelector',
+  get: ({ get }) => get(userAtom).followers ?? [],
+});
+
+export default followersSelector;

--- a/frontend/src/recoil/user/follows.ts
+++ b/frontend/src/recoil/user/follows.ts
@@ -1,0 +1,17 @@
+import { selector } from 'recoil';
+import userAtom from './atom';
+
+const followsSelector = selector<string[]>({
+  key: 'followsSelector',
+  get: ({ get }) => get(userAtom).follows ?? [],
+  set: ({ set }, newValue) => {
+    set(userAtom, (oldValue) => {
+      if (Array.isArray(newValue)) {
+        return { ...oldValue, follows: newValue };
+      }
+      return oldValue;
+    });
+  },
+});
+
+export default followsSelector;

--- a/frontend/src/recoil/user/index.ts
+++ b/frontend/src/recoil/user/index.ts
@@ -1,5 +1,7 @@
 import userAtom from './atom';
 import isAuthenticatedSelector from './isAuthenticated';
+import followsSelector from './follows';
+import followersSelector from './followers';
 
-export { isAuthenticatedSelector };
+export { isAuthenticatedSelector, followersSelector, followsSelector };
 export default userAtom;


### PR DESCRIPTION
### 한 일
- Follow Unfollow 버튼을 FollowSet으로 묶고 추상화
- userAtom의 파생 상태로 follows, followers를 만들었습니다. (follows는 set가능하도록 만들었습니다.)

### 파일 변경
- frontend/src/components/cards/UserInfoCard/index.tsx: FollowSet 컴포넌트 제작으로 인한 리팩토링
- frontend/src/components/sets/FollowSet/index.tsx: Unfollow, Follow 컴포넌트 묶어서 FollowSet으로 추상화
- frontend/src/recoil/user/followers.ts: userAtom에서 followers를 가져오는 selector 개발
- frontend/src/recoil/user/follows.ts: userAtom에서 follows를 가져오는 selector 개발
- frontend/src/recoil/user/index.ts: 새로 만든 selector 추가