### PR TITLE
Recoil과 Next의 사이 좋아지게 하기 ⭐️

### DIFF
--- a/frontend/src/components/cards/SuggestionCard/index.tsx
+++ b/frontend/src/components/cards/SuggestionCard/index.tsx
@@ -1,6 +1,6 @@
+import { useRecoilValue } from 'recoil';
 import { useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
-import PropTypes from 'prop-types';
 import { AiOutlineRight, AiOutlineLeft } from 'react-icons/ai';
 
 import CardCommon from 'src/components/cards/Common';
@@ -14,17 +14,14 @@ import {
   SUGGESTION_PROFILE_IMAGE_SIZE,
 } from 'src/globals/constants';
 
-import { UserType } from 'src/types';
-
 import { Fetcher } from 'src/utils';
+
+import userAtom from 'src/recoil/user';
 
 import { Title } from './style';
 
-interface Props {
-  user: UserType;
-}
-
-function SuggestionCard({ user }: Props) {
+function SuggestionCard() {
+  const user = useRecoilValue(userAtom);
   const { data: users } = useQuery(['suggestion', 'posts', user._id], () =>
     Fetcher.getUserSuggestions(user),
   );
@@ -73,9 +70,5 @@ function SuggestionCard({ user }: Props) {
     </CardCommon>
   );
 }
-
-SuggestionCard.propTypes = {
-  user: PropTypes.objectOf(PropTypes.any).isRequired,
-};
 
 export default SuggestionCard;

--- a/frontend/src/components/cards/UserInfoCard/index.tsx
+++ b/frontend/src/components/cards/UserInfoCard/index.tsx
@@ -1,3 +1,4 @@
+import { useRecoilValue } from 'recoil';
 import { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { IoSettingsOutline } from 'react-icons/io5';
@@ -16,14 +17,16 @@ import {
   USER_INFO_CARD_WIDTH,
 } from 'src/globals/constants';
 
+import userAtom from 'src/recoil/user';
+
 import { Wrapper, ImageHolder, Username } from './style';
 
 interface Props {
   targetUser: UserType;
-  user: UserType;
 }
 
-function UserInfoCard({ targetUser, user }: Props) {
+function UserInfoCard({ targetUser }: Props) {
+  const user = useRecoilValue(userAtom);
   const { profileImage, username, postCount, followCount, name, bio } = targetUser;
   const [followerCount, setFollowerCount] = useState(targetUser.followerCount ?? 0);
 
@@ -81,7 +84,6 @@ function UserInfoCard({ targetUser, user }: Props) {
 
 UserInfoCard.prototype = {
   targetUser: PropTypes.objectOf(PropTypes.any).isRequired,
-  user: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 export default UserInfoCard;

--- a/frontend/src/components/cards/UserSettingsCard/index.tsx
+++ b/frontend/src/components/cards/UserSettingsCard/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import PropTypes from 'prop-types';
 import { useMutation } from 'react-query';
+import { useRecoilValue } from 'recoil';
 
 import CardCommon from 'src/components/cards/Common';
 import Input from 'src/components/inputs/Common';
@@ -8,8 +8,6 @@ import Button from 'src/components/buttons/Common';
 import ImageInput from 'src/components/inputs/ImageInput';
 import ProfileImage from 'src/components/images/ProfileImage';
 import { Row } from 'src/components/Grid';
-
-import { UserType } from 'src/types';
 
 import {
   USER_SETTING_CARD_WIDTH,
@@ -19,13 +17,12 @@ import {
 
 import { Fetcher } from 'src/utils';
 
+import userAtom from 'src/recoil/user';
+
 import { Label, ImageHolder, ImageCover } from './style';
 
-interface Props {
-  user: UserType;
-}
-
-function UserSettingsCard({ user }: Props) {
+function UserSettingsCard() {
+  const user = useRecoilValue(userAtom);
   const [profileImage, setProfileImage] = useState(user.profileImage ?? DEFAULT_PROFILE_IMAGE);
   const [username, setUsername] = useState(user.username ?? '');
   const [name, setName] = useState(user.name ?? '');
@@ -72,9 +69,5 @@ function UserSettingsCard({ user }: Props) {
     </CardCommon>
   );
 }
-
-UserSettingsCard.prototype = {
-  user: PropTypes.objectOf(PropTypes.any).isRequired,
-};
 
 export default UserSettingsCard;

--- a/frontend/src/components/sets/FollowSet/index.tsx
+++ b/frontend/src/components/sets/FollowSet/index.tsx
@@ -37,7 +37,7 @@ function FollowSet({ targetUser, onFollow, onUnfollow }: Props) {
     onUnfollow();
   }, [onUnfollow, setFollows, targetUser._id]);
   if (isMe) {
-    return '';
+    return null;
   }
   return isFollow ? (
     <UnfollowButton targetUserID={targetUser._id!} onUnfollow={handleUnfollow} />

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,16 +1,31 @@
-import type { AppProps } from 'next/app';
+import type { AppContext, AppProps } from 'next/app';
 import { ThemeProvider, Global } from '@emotion/react';
-import { RecoilRoot } from 'recoil';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
 import { QueryClientProvider, QueryClient } from 'react-query';
 
 import { theme, global } from 'src/styles';
 
+import { UserType } from 'src/types';
+
+import { Fetcher } from 'src/utils';
+
+import userAtom from 'src/recoil/user';
+
 const queryClient = new QueryClient();
 
-function MyApp({ Component, pageProps }: AppProps) {
+const getInitialState =
+  (user: UserType) =>
+  ({ set }: MutableSnapshot) =>
+    set(userAtom, user);
+
+interface Props extends AppProps {
+  user: UserType;
+}
+
+function MyApp({ user, Component, pageProps }: Props) {
   return (
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
+      <RecoilRoot initializeState={getInitialState(user)}>
         <ThemeProvider theme={theme}>
           <Global styles={global(theme)} />
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
@@ -20,5 +35,14 @@ function MyApp({ Component, pageProps }: AppProps) {
     </QueryClientProvider>
   );
 }
+
+MyApp.getInitialProps = async (context: AppContext) => {
+  const token = context.ctx.req?.headers.cookie?.split('=')[1];
+  if (token === undefined) {
+    return { user: {} };
+  }
+  const user: UserType = await Fetcher.getUsersMe(token);
+  return { user: { ...user, token } };
+};
 
 export default MyApp;

--- a/frontend/src/pages/users/[username].tsx
+++ b/frontend/src/pages/users/[username].tsx
@@ -17,18 +17,14 @@ import { USERS_DESCRIPTION } from 'src/globals/descriptions';
 
 import { Page } from 'src/styles';
 
-import userAtom from 'src/recoil/user';
 import postsAtom from 'src/recoil/posts';
 
 interface Props {
-  user: UserType;
   targetUser: UserType;
 }
 
-function User({ user, targetUser }: Props) {
-  const setUser = useSetRecoilState(userAtom);
+function User({ targetUser }: Props) {
   const setPosts = useSetRecoilState(postsAtom);
-  useEffect(() => setUser(user), [setUser, user]);
 
   const isUserExist = Object.keys(targetUser).length !== 0;
   const { isSuccess, data: posts } = useQuery(['user', 'posts', targetUser._id], () => {
@@ -56,7 +52,7 @@ function User({ user, targetUser }: Props) {
         <Col alignItems='center'>
           {isUserExist ? (
             <>
-              <UserInfoCard targetUser={targetUser} user={user} />
+              <UserInfoCard targetUser={targetUser} />
               <Timeline />
             </>
           ) : (
@@ -81,12 +77,9 @@ export async function getServerSideProps(context: any) {
       },
     };
   }
-  const usersByUsernameRequest = Fetcher.getUsersByUsername(token, username);
-  const usersMeRequests = Fetcher.getUsersMe(token);
-  const targetUser = await usersByUsernameRequest;
-  const user = await usersMeRequests;
+  const targetUser = await Fetcher.getUsersByUsername(token, username);
   return {
-    props: { user: { ...user, token }, targetUser },
+    props: { targetUser },
   };
 }
 

--- a/frontend/src/pages/users/[username]/settings.tsx
+++ b/frontend/src/pages/users/[username]/settings.tsx
@@ -1,31 +1,25 @@
 import Head from 'next/head';
-import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
 
 import Header from 'src/components/Header';
 import FloatingButton from 'src/components/buttons/FloatingButton';
 import UserSettingsCard from 'src/components/cards/UserSettingsCard';
 import { Row } from 'src/components/Grid';
 
-import { UserType } from 'src/types';
-
-import { Fetcher } from 'src/utils';
 import { SETTING_DESCRIPTION } from 'src/globals/descriptions';
 
 import { Page } from 'src/styles';
 
 import userAtom from 'src/recoil/user';
 
-interface Props {
-  user: UserType;
-}
-
-function Settings({ user }: Props) {
-  const setUser = useSetRecoilState(userAtom);
-  useEffect(() => setUser(user), [setUser, user]);
+function Settings() {
+  const router = useRouter();
+  const targetUsername = router.query.username;
+  const user = useRecoilValue(userAtom);
 
   return (
-    <div>
+    <>
       <Head>
         <title>COCOO</title>
         <meta name='description' content={SETTING_DESCRIPTION} />
@@ -35,35 +29,13 @@ function Settings({ user }: Props) {
       <Header />
       <Page.Main>
         <Row justifyContent='center'>
-          <UserSettingsCard user={user} />
+          {targetUsername === user.username ? <UserSettingsCard /> : <p>퍼미션 디나이드</p>}
         </Row>
       </Page.Main>
       <FloatingButton />
       <footer />
-    </div>
+    </>
   );
-}
-
-export async function getServerSideProps(context: any) {
-  const { username } = context.query;
-  const token = context.req?.cookies.jwt;
-  const redirect = {
-    permanent: false,
-    destination: '/',
-  };
-  if (token === undefined) {
-    return { redirect };
-  }
-  const usersByUsernameRequest = Fetcher.getUsersByUsername(token, username);
-  const usersMeRequests = Fetcher.getUsersMe(token);
-  const targetUser = await usersByUsernameRequest;
-  const user = await usersMeRequests;
-  if (targetUser._id !== user._id) {
-    return { redirect };
-  }
-  return {
-    props: { user: { ...user, token } },
-  };
 }
 
 export default Settings;


### PR DESCRIPTION
### 현 실태
`geServerSideProps` 함수내에서 access token으로 인증된 유저 정보를 요청고,
각 pages component에서 `useSetRecoilState`함수를 통해 `userAtom`에 유저 정보를 저장했습니다.

하지만 recoil 상태의 setState는 비동기 작업으로 처리되었고, 다른 컴포넌트에서 유저 상태를 사용한다면
20ms ~ 50ms 이후에 유저 정보가 불러와 지는 것을 확인했습니다.

그래서 유저 정보가 즉시 필요한 컴포넌트는 props로 넘겨주었고, 그렇지 않은 컴포넌트는 상태값을 사용했습니다.
이렇게 함에 따라 props drilling 등의 문제로 인해 복잡도가 증가했고, 
그렇다고 모두 상태로 불러오자니 딜레이로 인해 server side rendering의 장점을 버린다고 생각했습니다.
그래서 계속 찝찝하게 코딩을 하던 와중! 해결할 수 있는 키워드를 발견했습니다!

### 개선 점
`RecoilRoot` 컴포넌트에서 `initializeState` 프롭스가 있다는 것을 발견했습니다.
 이 함수를 활용하여 초기의 상태를 set한다면 20ms ~ 50ms의 딜레이없이 (동기적으로) 처리되는 것을 확인했습니다.

### 결론
이 PR은 유저 상태를 모두 전역상태로 migration하고 모든 컴포넌트의 props에서 제거한 작업물 입니다.
그리고 이제 개발하실 때 유저 정보는 는 전역 상태로 들고 오시면 됩니다~

### 파일 변경
- frontend/src/components/cards/SuggestionCard/index.tsx: user props 제거
- frontend/src/components/cards/UserInfoCard/index.tsx: user props 제거
- frontend/src/components/cards/UserSettingsCard/index.tsx: user props 제거
- frontend/src/pages/_app.tsx: getInitialProps 호출 및 토큰으로 유저 정보 fetch
- frontend/src/pages/home.tsx: user props 제거 및 `getServerSideProps` 함수 삭제
- frontend/src/pages/users/[username].tsx: user props 제거
- frontend/src/pages/users/[username]/settings.tsx: user props 제거 및 `getServerSideProps` 함수 삭제
- frontend/src/components/sets/FollowSet/index.tsx: 리턴 타입 fix
 