### PR TITLE
무한 스크롤 대응 상태값 변경 및 리팩토링

### DIFF
--- a/frontend/src/components/Timeline/index.tsx
+++ b/frontend/src/components/Timeline/index.tsx
@@ -1,19 +1,23 @@
-import { useRecoilValue } from 'recoil';
+import PropTypes from 'prop-types';
 
 import Post from 'src/components/Post';
 
-import postsAtom from 'src/recoil/posts';
+import { PostType } from 'src/types';
 
-function Timeline() {
-  const posts = useRecoilValue(postsAtom);
-
-  return (
-    <>
-      {posts.map((post) => (
-        <Post post={post} key={post._id} />
-      ))}
-    </>
-  );
+interface Props {
+  pages?: PostType[][];
 }
+
+function Timeline({ pages }: Props) {
+  return <>{pages!.map((posts) => posts.map((post) => <Post key={post._id} post={post} />))}</>;
+}
+
+Timeline.protoTypes = {
+  pages: PropTypes.arrayOf(PropTypes.object),
+};
+
+Timeline.defaultProps = {
+  pages: [],
+};
 
 export default Timeline;

--- a/frontend/src/components/buttons/FloatingButton/index.tsx
+++ b/frontend/src/components/buttons/FloatingButton/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import ButtonCommon from 'src/components/buttons/Common';
 import PostWriteModal from 'src/components/modals/PostWriteModal';
@@ -7,7 +8,11 @@ import { FLOATING_BUTTON_WIDTH, FLOATING_BUTTON_HEIGHT } from 'src/globals/const
 
 import { Wrapper } from './style';
 
-function FloatingButton() {
+interface Props {
+  onPostWrite?: () => void;
+}
+
+function FloatingButton({ onPostWrite }: Props) {
   const [isModalShow, setIsModalShow] = useState(false);
 
   const changeModalShow = useCallback(() => {
@@ -20,7 +25,7 @@ function FloatingButton() {
 
   return (
     <Wrapper>
-      {isModalShow && <PostWriteModal onClose={handleClose} />}
+      {isModalShow && <PostWriteModal onClose={handleClose} onPostWrite={onPostWrite} />}
       <ButtonCommon
         onClick={changeModalShow}
         width={FLOATING_BUTTON_WIDTH}
@@ -31,5 +36,13 @@ function FloatingButton() {
     </Wrapper>
   );
 }
+
+FloatingButton.prototype = {
+  onPostWrite: PropTypes.func,
+};
+
+FloatingButton.defaultProps = {
+  onPostWrite: () => {},
+};
 
 export default FloatingButton;

--- a/frontend/src/components/cards/SuggestionCard/index.tsx
+++ b/frontend/src/components/cards/SuggestionCard/index.tsx
@@ -1,11 +1,13 @@
 import { useRecoilValue } from 'recoil';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
 import { AiOutlineRight, AiOutlineLeft } from 'react-icons/ai';
 
 import CardCommon from 'src/components/cards/Common';
 import ProfileImageButton from 'src/components/buttons/ProfileImageButton';
 import IconButton from 'src/components/buttons/IconButton';
+import FollowSet from 'src/components/sets/FollowSet';
+import UsernameButton from 'src/components/buttons/UsernameButton';
 import { Row, Col } from 'src/components/Grid';
 
 import {
@@ -16,25 +18,17 @@ import {
 
 import { Fetcher } from 'src/utils';
 
-import userAtom, { isRegisteredSelector } from 'src/recoil/user';
+import userAtom from 'src/recoil/user';
 
-import FollowSet from 'src/components/sets/FollowSet';
-import UsernameButton from 'src/components/buttons/UsernameButton';
 import { Title } from './style';
 
 function SuggestionCard() {
   const user = useRecoilValue(userAtom);
-  const isRegister = useRecoilValue(isRegisteredSelector);
-  const { data: users, refetch } = useQuery(['suggestion', 'posts', user._id], () =>
+  const { data: users } = useQuery(['suggestion', 'posts', user], () =>
     Fetcher.getUserSuggestions(user),
   );
-  const [startIndex, setStartIndex] = useState(0);
-  useEffect(() => {
-    if (isRegister) {
-      refetch();
-    }
-  }, [refetch, isRegister]);
 
+  const [startIndex, setStartIndex] = useState(0);
   const handleClickLeft = useCallback(() => {
     setStartIndex((prevState) => prevState - 1);
   }, []);
@@ -44,7 +38,7 @@ function SuggestionCard() {
 
   const isFirst = useMemo(() => startIndex === 0, [startIndex]);
   const isLast = useMemo(
-    () => startIndex === (users ?? []).length - SUGGESTION_COUNT,
+    () => startIndex >= (users ?? []).length - SUGGESTION_COUNT,
     [startIndex, users],
   );
 

--- a/frontend/src/components/inputs/Common/index.tsx
+++ b/frontend/src/components/inputs/Common/index.tsx
@@ -1,10 +1,10 @@
-import React, { Dispatch, ReactNode, SetStateAction, useCallback, useState } from 'react';
+import React, { Dispatch, ReactNode, SetStateAction, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { Wrapper, Input } from './style';
 
 interface Props {
-  bind?: [string, Dispatch<SetStateAction<string>>];
+  bind: [string, Dispatch<SetStateAction<string>>];
   placeholder?: string;
   width?: number;
   icon?: ReactNode;
@@ -13,33 +13,27 @@ interface Props {
 }
 
 function InputCommon({ bind, placeholder, width, icon, onChange }: Props) {
-  const [state, setState] = bind!;
-  const [fallbackState, setFallbackState] = useState('');
+  const [state, setState] = bind;
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setState(event.target.value);
-      setFallbackState(event.target.value);
-      onChange!(event.target.value);
+      const newState = event.target.value;
+      setState(newState);
+      onChange!(newState);
     },
     [onChange, setState],
   );
 
   return (
     <Wrapper width={width!}>
-      <Input
-        width={width!}
-        value={state || fallbackState}
-        onChange={handleChange}
-        placeholder={placeholder}
-      />
+      <Input width={width!} value={state} onChange={handleChange} placeholder={placeholder} />
       {icon}
     </Wrapper>
   );
 }
 
 InputCommon.propTypes = {
-  bind: PropTypes.arrayOf(PropTypes.any),
+  bind: PropTypes.arrayOf(PropTypes.any).isRequired,
   placeholder: PropTypes.string,
   width: PropTypes.number,
   icon: PropTypes.node,
@@ -47,7 +41,6 @@ InputCommon.propTypes = {
 };
 
 InputCommon.defaultProps = {
-  bind: ['', () => {}],
   placeholder: '',
   width: 0,
   icon: '',

--- a/frontend/src/components/inputs/SearchInput/index.tsx
+++ b/frontend/src/components/inputs/SearchInput/index.tsx
@@ -15,12 +15,13 @@ import { Fetcher } from 'src/utils';
 import { UserType } from 'src/types';
 
 function SearchInput() {
+  const [value, setValue] = useState('');
   const [userResults, setUserResults] = useState<UserType[]>([]);
-  const mutation = useMutation((value: string) => Fetcher.getSearch(value));
+  const mutation = useMutation((newValue: string) => Fetcher.getSearch(newValue));
 
-  const handleChange = async (value: string) => {
-    if (value !== '') {
-      const results = await mutation.mutateAsync(value);
+  const handleChange = async (newValue: string) => {
+    if (newValue !== '') {
+      const results = await mutation.mutateAsync(newValue);
       setUserResults(results);
     } else {
       setUserResults([]);
@@ -42,6 +43,7 @@ function SearchInput() {
         </HeaderModal>
       )}
       <InputCommon
+        bind={[value, setValue]}
         placeholder='search'
         width={SEARCH_INPUT_WIDTH}
         icon={<IoSearchSharp />}

--- a/frontend/src/components/modals/PostWriteModal/index.tsx
+++ b/frontend/src/components/modals/PostWriteModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { useMutation } from 'react-query';
 import { IoMdImages } from 'react-icons/io';
 import PropTypes from 'prop-types';
@@ -11,25 +11,21 @@ import PreviewImages from 'src/components/images/PreviewImages';
 import { Fetcher } from 'src/utils';
 
 import userAtom from 'src/recoil/user';
-import postsAtom from 'src/recoil/posts';
-
-import { PostType } from 'src/types';
 
 import { Textarea, IconHolder } from './style';
 
 interface Props {
+  onPostWrite: () => void;
   onClose: () => void;
 }
 
-function PostWriteModal({ onClose }: Props) {
+function PostWriteModal({ onClose, onPostWrite }: Props) {
   const [content, setContent] = useState('');
   const [images, setImages] = useState<string[]>([]);
-  const setPosts = useSetRecoilState(postsAtom);
   const user = useRecoilValue(userAtom);
   const mutation = useMutation(() => Fetcher.postPost(user, content, images), {
-    onSuccess: ({ result: post }) => {
-      setPosts((posts: PostType[]) => [post, ...posts]);
-      onClose();
+    onSuccess: () => {
+      onPostWrite();
     },
   });
 
@@ -69,10 +65,12 @@ function PostWriteModal({ onClose }: Props) {
 
 PostWriteModal.propTypes = {
   onClose: PropTypes.func,
+  onPostWrite: PropTypes.func,
 };
 
 PostWriteModal.defaultProps = {
   onClose: () => {},
+  onPostWrite: () => {},
 };
 
 export default PostWriteModal;

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useQuery } from 'react-query';
 
@@ -12,7 +12,6 @@ import LoadingIndicator from 'src/components/LoadingIndicator';
 import { Col } from 'src/components/Grid';
 
 import userAtom, {
-  followsSelector,
   hasFollowSelector,
   isAuthenticatedSelector,
   isRegisteredSelector,
@@ -30,33 +29,16 @@ import { FAVICON } from 'src/globals/constants';
 function Home() {
   const user = useRecoilValue(userAtom);
   const hasFollow = useRecoilValue(hasFollowSelector);
-  const follows = useRecoilValue(followsSelector);
   const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
   const isRegistered = useRecoilValue(isRegisteredSelector);
   const setPosts = useSetRecoilState(postsAtom);
 
   const [hasFollowTemp] = useState(hasFollow);
-  const { refetch, isFetched } = useQuery(
-    ['home', 'posts', user._id],
-    () => Fetcher.getPosts(user),
-    {
-      onSuccess: (posts) => {
-        setPosts(posts!);
-      },
+  const { isFetched } = useQuery(['home', 'posts', user], () => Fetcher.getPosts(user), {
+    onSuccess: (posts) => {
+      setPosts(posts!);
     },
-  );
-
-  // when registered
-  useEffect(() => {
-    if (isRegistered) {
-      refetch();
-    }
-  }, [isRegistered, refetch]);
-
-  // when follows new user
-  useEffect(() => {
-    refetch();
-  }, [follows, refetch]);
+  });
 
   return (
     <>

--- a/frontend/src/pages/random.tsx
+++ b/frontend/src/pages/random.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
-import { useSetRecoilState } from 'recoil';
-import { useQuery } from 'react-query';
+import { useInfiniteQuery } from 'react-query';
 
 import Timeline from 'src/components/Timeline';
 import Header from 'src/components/Header';
@@ -11,14 +10,11 @@ import { FAVICON } from 'src/globals/constants';
 
 import { Page } from 'src/styles';
 
-import postsAtom from 'src/recoil/posts';
-
 import { Fetcher } from 'src/utils';
 
 function Random() {
-  const setPosts = useSetRecoilState(postsAtom);
-  const { isFetched } = useQuery(['random', 'posts'], () => Fetcher.getRandomPosts(), {
-    onSuccess: (posts) => setPosts(posts),
+  const { data } = useInfiniteQuery(['random', 'posts'], () => Fetcher.getRandomPosts(), {
+    getNextPageParam: (lastPage) => lastPage, // @TODO nextCursor property update
   });
   return (
     <>
@@ -30,7 +26,9 @@ function Random() {
 
       <Header />
       <Page.Main>
-        <Col alignItems='center'>{isFetched && <Timeline />}</Col>
+        <Col alignItems='center'>
+          <Timeline pages={data?.pages} />
+        </Col>
       </Page.Main>
     </>
   );

--- a/frontend/src/pages/users/[username]/settings.tsx
+++ b/frontend/src/pages/users/[username]/settings.tsx
@@ -10,14 +10,15 @@ import { Row } from 'src/components/Grid';
 import { SETTING_DESCRIPTION } from 'src/globals/descriptions';
 import { FAVICON } from 'src/globals/constants';
 
-import { Page } from 'src/styles';
+import userAtom, { isRegisteredSelector } from 'src/recoil/user';
 
-import userAtom from 'src/recoil/user';
+import { Page } from 'src/styles';
 
 function Settings() {
   const router = useRouter();
   const targetUsername = router.query.username;
   const user = useRecoilValue(userAtom);
+  const isRegistered = useRecoilValue(isRegisteredSelector);
 
   return (
     <>
@@ -33,7 +34,7 @@ function Settings() {
           {targetUsername === user.username ? <UserSettingsCard /> : <p>퍼미션 디나이드</p>}
         </Row>
       </Page.Main>
-      <FloatingButton />
+      {isRegistered && <FloatingButton />}
     </>
   );
 }

--- a/frontend/src/recoil/posts/atom.ts
+++ b/frontend/src/recoil/posts/atom.ts
@@ -1,9 +1,0 @@
-import { atom } from 'recoil';
-import type { PostType } from 'src/types';
-
-const postsAtom = atom<PostType[]>({
-  key: 'postsAtom',
-  default: [],
-});
-
-export default postsAtom;

--- a/frontend/src/recoil/posts/index.ts
+++ b/frontend/src/recoil/posts/index.ts
@@ -1,3 +1,0 @@
-import postsAtom from './atom';
-
-export default postsAtom;

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -20,8 +20,9 @@ class Fetcher {
 
   static async getUsersByUsername(token: string, username: string): Promise<UserType> {
     try {
-      const result = await axios.get(`${baseURL}/${version}/users?username=${username}`, {
+      const result = await axios.get(`${baseURL}/${version}/users`, {
         headers: { Authorization: `Bearer ${token}` },
+        params: { username },
       });
       return result.data;
     } catch (error) {
@@ -34,8 +35,9 @@ class Fetcher {
     if (user._id === undefined || !user.isRegistered) {
       return [];
     }
-    const result = await axios.get(`${baseURL}/${version}/posts/?user_id=${user._id}&offset=${0}`, {
+    const result = await axios.get(`${baseURL}/${version}/posts`, {
       headers: { Authorization: `Bearer ${user.token}` },
+      params: { user_id: user._id, offset: 0 },
     });
     return result.data;
   }

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { QueryFunctionContext } from 'react-query';
 
 import { UserType, PostType, LikeType, ReturnType, CommentType } from 'src/types';
 
@@ -31,13 +32,13 @@ class Fetcher {
   }
 
   // for client side
-  static async getPosts(user: UserType): Promise<PostType[]> {
+  static async getPosts(user: UserType, { pageParam }: QueryFunctionContext): Promise<PostType[]> {
     if (user._id === undefined || !user.isRegistered) {
       return [];
     }
     const result = await axios.get(`${baseURL}/${version}/posts`, {
       headers: { Authorization: `Bearer ${user.token}` },
-      params: { user_id: user._id, offset: 0 },
+      params: { user_id: user._id, offset: pageParam ?? 0 },
     });
     return result.data;
   }


### PR DESCRIPTION
### 한 일
- useQuery의 키값을 user객체 전체로 변경하여 좀 더 선언적 fetching이 되도록함
- 무한 스크롤 대응 useQuery를 useInfiniteQuery로 변경
- 무한 스크롤 대응 프로토타입 변경
- 무한 스크롤 대응 posts 상태 삭제

### 파일 변경
- frontend/src/components/Timeline/index.tsx: 타임라인에서 posts 2차원 배열 props 받도록 변경
- frontend/src/components/buttons/FloatingButton/index.tsx: posts 상태 삭제에 따른 props 업데이트
- frontend/src/components/cards/SuggestionCard/index.tsx: useQuery 키값 변경에 따른 리팩토링
- frontend/src/components/inputs/Common/index.tsx: 인풋 공동 상태 보유로 인한 버그 해결
- frontend/src/components/inputs/SearchInput/index.tsx: 인풋 컴포넌트 업데이트로 인한 리팩토링
- frontend/src/components/modals/PostWriteModal/index.tsx: posts 상태 삭제에 따른 업데이트
- frontend/src/pages/home.tsx: useQuery 키값 변경에 따른 리팩토링
- frontend/src/pages/random.tsx: 무한 스크롤 대응 업데이트
- frontend/src/pages/users/[username].tsx: 무한 스크롤 대응 업데이트
- frontend/src/pages/users/[username]/settings.tsx: 회원가입을 하지 않은 유저에게 글 작성 버튼이 안보이도록 변경
- frontend/src/utils/Fetcher.ts: 무한 스크롤 대응 업데이트
