### PR TITLE
대시보드 관련 API들 구현

### DIFF
--- a/backend/src/loaders/passportGithubLoader.ts
+++ b/backend/src/loaders/passportGithubLoader.ts
@@ -19,18 +19,19 @@ export default function passportGithubLoader(): void {
   ) => {
     try {
       const { id, login: username } = profile._json;
-      const userIsExist = await UserService.existGithubUser(username);
-      let user;
-      if (userIsExist) {
-        const temp = await UserService.updateGithubUserInfo(username, { githubUsername: username });
-        user = { userID: temp };
-      } else {
-        user = await UserService.findOrCreateUserForProvider({
-          authProvider: 'github',
-          authProviderID: id,
-          githubUsername: username,
-        });
-      }
+      // const userIsExist = await UserService.existGithubUser(username);
+      // let user;
+      // if (userIsExist) {
+      //   const temp = await UserService.updateGithubUserInfo(username, { githubUsername: username });
+      //   user = { userID: temp };
+      // } else {
+      //   user = await UserService.findOrCreateUserForProvider({
+      //     authProvider: 'github',
+      //     authProviderID: id,
+      //     githubUsername: username,
+      //   });
+      // }
+      const user = { _id: id, username };
 
       return cb(null, user);
     } catch (err) {

--- a/backend/src/loaders/passportGithubLoader.ts
+++ b/backend/src/loaders/passportGithubLoader.ts
@@ -19,18 +19,6 @@ export default function passportGithubLoader(): void {
   ) => {
     try {
       const { id, login: username } = profile._json;
-      // const userIsExist = await UserService.existGithubUser(username);
-      // let user;
-      // if (userIsExist) {
-      //   const temp = await UserService.updateGithubUserInfo(username, { githubUsername: username });
-      //   user = { userID: temp };
-      // } else {
-      //   user = await UserService.findOrCreateUserForProvider({
-      //     authProvider: 'github',
-      //     authProviderID: id,
-      //     githubUsername: username,
-      //   });
-      // }
       const user = { _id: id, username };
 
       return cb(null, user);

--- a/backend/src/models/DashboardRepository.ts
+++ b/backend/src/models/DashboardRepository.ts
@@ -6,8 +6,12 @@ import { Validate } from 'src/utils';
 const dashboardRepositorySchema = new Schema<DashboardRepositoryType>(
   {
     userID: { type: Types.ObjectId, required: true, ref: 'User', validate: Validate.userObjectID },
-    title: { type: String },
+    repoName: { type: String, required: true },
+    repoUrl: { type: String, required: true },
+    startCount: { type: Number },
+    forktCount: { type: Number },
     content: { type: String },
+    languageInfo: { any: { type: Number } },
   },
   { versionKey: false, timestamps: true },
 );

--- a/backend/src/models/DashboardRepository.ts
+++ b/backend/src/models/DashboardRepository.ts
@@ -11,7 +11,7 @@ const dashboardRepositorySchema = new Schema<DashboardRepositoryType>(
     startCount: { type: Number },
     forktCount: { type: Number },
     content: { type: String },
-    languageInfo: { any: { type: Number } },
+    languageInfo: { type: Object },
   },
   { versionKey: false, timestamps: true },
 );

--- a/backend/src/routers/v1/socials.ts
+++ b/backend/src/routers/v1/socials.ts
@@ -98,46 +98,6 @@ export default class SocialsRouter {
     response.cookie('jwt', accessToken, cookieOptions);
     return `${process.env.CLIENT_URL}`;
   }
-  /**
-  // @UseBefore(passport.authenticate('github', { session: false }))
-  @Get('/github')
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getGithub(@Req() request: Request, @Res() response: Response) {
-    const { user_id: userID } = request.query;
-    passport.authenticate('github', {
-      session: false,
-      state: userID as string,
-    })(request, response);
-    return response;
-  }
-
-  @Get('/github/callback')
-  @UseBefore(passport.authenticate('github', { session: false }))
-  @Redirect(`${process.env.CLIENT_URL}`)
-  async getGithubCallback(@Req() request: Request, @Res() response: Response) {
-    const { id: authProviderID, username: githubUsername } = request.user as any;
-    const { state: userID } = request.query;
-
-    const userIsExist = userID ? await UserService.existGithubUser(userID as string) : false;
-    let user;
-    if (userIsExist) {
-      user = await UserService.updateGithubUserInfo(userID as string, { githubUsername });
-    } else {
-      user = await UserService.findOrCreateUserForProvider({
-        authProvider: 'github',
-        authProviderID,
-        githubUsername,
-      });
-    }
-
-    const accessToken = JWT.createAccessToken(user! as Express.User); // user!
-    response.cookie('jwt', accessToken, {
-      maxAge: Number(process.env.JWT_ACCESS_EXPIRE_IN!),
-      httpOnly: true,
-    });
-    return response;
-  }
- */
 
   @Get('/velog')
   @UseBefore(passport.authenticate('jwt-registered', { session: false }))

--- a/backend/src/routers/v1/socials.ts
+++ b/backend/src/routers/v1/socials.ts
@@ -57,8 +57,6 @@ export default class SocialsRouter {
     return `${process.env.CLIENT_URL}${request.query.state}`;
   }
 
-  // @UseBefore(passport.authenticate('github', { session: false }))
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   @Get('/github')
   getGithub(@Req() request: Request, @Res() response: Response) {
     const { user_id: userID } = request.query;

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -163,7 +163,8 @@ export default class UsersRouter {
     return response.json({ code: RESPONSECODE.SUCCESS, data: postContent });
   }
 
-  @Get('/:githubUsername/repositories/:repoName')
+  @Get('/:userID/repositories/:repoName')
+  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
   async getRepo(@Req() request: Request, @Res() response: Response) {
     const { userID, repoName } = request.params;
     if (userID !== request.user!.userID) {

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -182,11 +182,14 @@ export default class UsersRouter {
   @Get('/:userID/dashboard/repositories')
   async getDashboardRepoList(@Req() request: Request, @Res() response: Response) {
     const { userID } = request.params;
-    const githubUsername = await UserService.findUserGithubUsername(userID);
-    if (githubUsername === undefined) {
-      throw new Error(ERROR.NO_GITHUBUSERNAME);
-    }
     const result = await DashboardRepoService.readDashboardRepos(userID);
+    return response.json({ code: RESPONSECODE.SUCCESS, data: result });
+  }
+
+  @Get('/:userID/dashboard/repositories/languages')
+  async getDashboardReposLanguage(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    const result = await DashboardRepoService.readDashboardReposLanguage(userID);
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
   }
 

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -179,6 +179,17 @@ export default class UsersRouter {
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
   }
 
+  @Get('/:userID/dashboard/repositories')
+  async getDashboardRepoList(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    const githubUsername = await UserService.findUserGithubUsername(userID);
+    if (githubUsername === undefined) {
+      throw new Error(ERROR.NO_GITHUBUSERNAME);
+    }
+    const result = await DashboardRepoService.readDashboardRepos(userID);
+    return response.json({ code: RESPONSECODE.SUCCESS, data: result });
+  }
+
   @Post('/:userID/follows')
   @UseBefore(passport.authenticate('jwt-registered', { session: false }))
   async putUserFollows(@Req() request: Request, @Res() response: Response) {

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -138,10 +138,9 @@ export default class UsersRouter {
     if (userID !== request.user!.userID) {
       throw new Error(ERROR.PERMISSION_DENIED);
     }
-    /**
-     * @todo: userID를 받아서 db 상에 github username을 받아와 넣어주도록 추후에 변경해야함
-     */
-    const result = await GitService.findRepoList(userID);
+    const githubUsername = await UserService.findGithubUsername(userID);
+
+    const result = await GitService.findRepoList(githubUsername);
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
   }
 

--- a/backend/src/services/DashboardRepoService.ts
+++ b/backend/src/services/DashboardRepoService.ts
@@ -1,4 +1,5 @@
 import { DashboardRepository } from 'src/models';
+import { Calculate } from 'src/utils';
 
 class DashboardRepoService {
   async createDashboardRepo(userID: string, repoData: object) {
@@ -7,6 +8,22 @@ class DashboardRepoService {
 
   async readDashboardRepos(userID: string) {
     return DashboardRepository.find({ userID });
+  }
+
+  async readDashboardReposLanguage(userID: string) {
+    const data = await DashboardRepository.find({ userID }, 'languageInfo -_id').lean();
+    const temp: any = {};
+    data.forEach((repo: any) => {
+      Object.entries(repo.languageInfo).forEach((v) => {
+        if (Object.prototype.hasOwnProperty.call(temp, v[0])) {
+          temp[v[0]] += v[1] as number;
+        } else {
+          temp[v[0]] = v[1] as number;
+        }
+      });
+    });
+    const result = Calculate.calculateLanguage(temp);
+    return result;
   }
 }
 

--- a/backend/src/services/DashboardRepoService.ts
+++ b/backend/src/services/DashboardRepoService.ts
@@ -1,10 +1,12 @@
 import { DashboardRepository } from 'src/models';
-import { ERROR } from 'src/utils';
-import { GitService } from 'src/services';
 
 class DashboardRepoService {
   async createDashboardRepo(userID: string, repoData: object) {
     return DashboardRepository.create({ userID, ...repoData });
+  }
+
+  async readDashboardRepos(userID: string) {
+    return DashboardRepository.find({ userID });
   }
 }
 

--- a/backend/src/services/DashboardRepoService.ts
+++ b/backend/src/services/DashboardRepoService.ts
@@ -1,0 +1,11 @@
+import { DashboardRepository } from 'src/models';
+import { ERROR } from 'src/utils';
+import { GitService } from 'src/services';
+
+class DashboardRepoService {
+  async createDashboardRepo(userID: string, repoData: object) {
+    return DashboardRepository.create({ userID, ...repoData });
+  }
+}
+
+export default new DashboardRepoService();

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -26,6 +26,11 @@ class UserService {
     return User.exists({ username: query });
   }
 
+  async findGithubUsername(userID: string) {
+    const data: any = await User.findOne({ _id: userID }, 'githubUsername -_id');
+    return data.githubUsername;
+  }
+
   async findOneUserVelogToken(userID: string) {
     return User.findOne({ _id: userID }, 'blogAuthentication.velog -_id').lean();
   }

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -10,8 +10,8 @@ class UserService {
     return User.exists({ _id: user.userID });
   }
 
-  async existGithubUser(username: string): Promise<boolean> {
-    return User.exists({ githubUsername: username });
+  async existGithubUser(userID: string): Promise<boolean> {
+    return User.exists({ _id: userID });
   }
 
   async existsRegisteredUser(user: UserType): Promise<boolean> {
@@ -129,8 +129,8 @@ class UserService {
     );
   }
 
-  async updateGithubUserInfo(username: string, info: any) {
-    return User.findOneAndUpdate({ githubUsername: username }, info, { new: true });
+  async updateGithubUserInfo(userID: string, info: any) {
+    return User.findOneAndUpdate({ _id: userID }, info, { new: true });
   }
 
   async updateOneUserConfig(userID: string, userConfig: ObjectType<UserSchemaType>) {

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -12,3 +12,4 @@ export { default as ImageService } from './ImageService';
 export { default as ObjectStorageService } from './ObjectStorageService';
 export { default as NotifyService } from './NotifyService';
 export { default as FollowService } from './FollowService';
+export { default as DashboardRepoService } from './DashboardRepoService';

--- a/backend/src/types/modelType.ts
+++ b/backend/src/types/modelType.ts
@@ -61,8 +61,12 @@ export interface UserType {
 export interface DashboardRepositoryType {
   _id?: Types.ObjectId;
   userID?: Types.ObjectId;
-  title?: string;
+  repoName?: string;
+  repoUrl?: string;
+  startCount?: number;
+  forktCount?: number;
   content?: string;
+  languageInfo?: object;
   createdAt?: Date;
   updatedAt?: Date;
 }

--- a/backend/src/types/modelType.ts
+++ b/backend/src/types/modelType.ts
@@ -18,18 +18,18 @@ export interface NotifyRangeType {
 }
 
 export interface DashboardType {
-  name: string;
-  phoneNumber: string;
-  school: string;
-  region: string;
-  birthday: Date;
-  github: string;
-  blog: string;
-  solvedac: string;
-  email: string;
-  profileImage: string;
-  jobObjectives: string[];
-  techStacks: object;
+  name?: string;
+  phoneNumber?: string;
+  school?: string;
+  region?: string;
+  birthday?: Date;
+  github?: string;
+  blog?: string;
+  solvedac?: string;
+  email?: string;
+  profileImage?: string;
+  jobObjectives?: string[];
+  techStacks?: object;
 }
 
 export interface UserType {


### PR DESCRIPTION
### 제목
대시보드 관련 API들 구현

### 파일 변경
- backend/src/loaders/passportGithubLoader.ts  깃 인증 분기 나눔 (가입 or 유저네임 가져오기)
- backend/src/models/DashboardRepository.ts  대시보드 레포 스키마 변경
- backend/src/routers/v1/socials.ts  깃 인증 분기 나눔 (가입 or 유저네임 가져오기)
- backend/src/routers/v1/users.ts 에러 해결 및 대시보드 API 추가
- backend/src/services/DashboardRepoService.ts  대시보드 API 관련 서비스 코드
- backend/src/services/UserService.ts  잘못된 path parameter 정정
- backend/src/services/index.ts  export 추가
- backend/src/types/modelType.ts  ts 타입 ? 지정
