### PR TITLE
대시보드 기본 정보 가져오기, 업데이트, 사용자 연식 관련 API 추가

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -25,18 +25,18 @@ const dashboardSchema = new Schema<DashboardType>(
     email: { type: String, validate: [Validate.email, 'Email 형식이 잘못되었습니다.'] },
     profileImage: { type: String, validate: [Validate.url, 'URL 형식이 잘못되었습니다.'] },
     jobObjectives: [{ type: String, required: true }],
-    techStacks: {
-      any: {
-        type: [
+    techStacks: [
+      {
+        field: String,
+        stacks: [
           {
             type: Types.ObjectId,
-            required: true,
             ref: 'TechStack',
             validate: Validate.techStackObjectID,
           },
         ],
       },
-    },
+    ],
   },
   { _id: false },
 );

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -25,7 +25,18 @@ const dashboardSchema = new Schema<DashboardType>(
     email: { type: String, validate: [Validate.email, 'Email 형식이 잘못되었습니다.'] },
     profileImage: { type: String, validate: [Validate.url, 'URL 형식이 잘못되었습니다.'] },
     jobObjectives: [{ type: String, required: true }],
-    techStacks: { any: { type: [Types.ObjectId] } },
+    techStacks: {
+      any: {
+        type: [
+          {
+            type: Types.ObjectId,
+            required: true,
+            ref: 'TechStack',
+            validate: Validate.techStackObjectID,
+          },
+        ],
+      },
+    },
   },
   { _id: false },
 );

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -23,6 +23,7 @@ import {
   DashboardRepoService,
 } from 'src/services';
 import { ERROR, RESPONSECODE } from 'src/utils';
+import DashboardHistoryService from 'src/services/DashboardHistoryService';
 
 @Controller('/users')
 export default class UsersRouter {
@@ -80,7 +81,7 @@ export default class UsersRouter {
   @Get('/dashboard')
   async getDashboard(@Req() request: Request, @Res() response: Response) {
     const { username } = request.query;
-    const dashboard = await UserService.findOneUsernameDashboard(username as string);
+    const dashboard = await UserService.findOneUserDashboard({ username });
     return response.json(dashboard);
   }
 
@@ -232,6 +233,21 @@ export default class UsersRouter {
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
   }
 
+  @Post('/:userID/dashboard/histories')
+  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
+  async postDashboardHistory(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    const { content, date } = request.body;
+    if (userID !== request.user!.userID) {
+      throw new Error(ERROR.WRONG_PARAMS_TYPE);
+    }
+    if (!content || !date) {
+      throw new Error(ERROR.WRONG_BODY_TYPE);
+    }
+    const history = await DashboardHistoryService.createDashboardHistory(userID, content, date);
+    return response.json(history);
+  }
+
   @Put('/:userID/settings')
   @UseBefore(passport.authenticate('jwt', { session: false }))
   async putUser(@Req() request: Request, @Res() response: Response) {
@@ -251,7 +267,7 @@ export default class UsersRouter {
       throw new Error(ERROR.PERMISSION_DENIED);
     }
     await UserService.updateOneUserDashboard(userID, request.body);
-    const dashboard = await UserService.findOneUserIDDashboard(userID);
+    const dashboard = await UserService.findOneUserDashboard({ _id: userID });
     return response.json({ code: RESPONSECODE.SUCCESS, data: dashboard });
   }
 
@@ -267,6 +283,21 @@ export default class UsersRouter {
       throw new Error(ERROR.WRONG_PARAMS_TYPE);
     }
     await FollowService.removeFollow(request.user!.userID, userID);
+    return response.json({ code: RESPONSECODE.SUCCESS });
+  }
+
+  @Delete('/:userID/dashboard/histories')
+  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
+  async deleteUserDashboardHistory(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    const { historyID } = request.body;
+    if (userID !== request.user?.userID) {
+      throw new Error(ERROR.PERMISSION_DENIED);
+    }
+    if (!historyID) {
+      throw new Error(ERROR.WRONG_BODY_TYPE);
+    }
+    await DashboardHistoryService.deleteDashboardHistory(userID, historyID);
     return response.json({ code: RESPONSECODE.SUCCESS });
   }
 }

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -82,7 +82,11 @@ export default class UsersRouter {
   async getDashboard(@Req() request: Request, @Res() response: Response) {
     const { username } = request.query;
     const dashboard = await UserService.findOneUserDashboard({ username });
-    return response.json(dashboard);
+    const dashboardHistories = await DashboardHistoryService.findDashboardHistory(dashboard._id!);
+    return response.json({
+      code: RESPONSECODE.SUCCESS,
+      data: { _id: dashboard._id, dashboard: { ...dashboard.dashboard, dashboardHistories } },
+    });
   }
 
   @Get('/:userID/posts')

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -153,6 +153,17 @@ export default class UsersRouter {
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
   }
 
+  @Get('/:userID/dashboard')
+  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
+  async getDashboard(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    if (userID !== request.user?.userID) {
+      throw new Error(ERROR.PERMISSION_DENIED);
+    }
+    UserService.findOneUserDashboard(userID);
+    return response.json();
+  }
+
   @Get('/:userID/tistory/:identity/posts/:postID')
   @UseBefore(passport.authenticate('jwt-registered', { session: false }))
   async getTistoryPostContent(@Req() request: Request, @Res() response: Response) {

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -80,7 +80,7 @@ export default class UsersRouter {
   @Get('/dashboard')
   async getDashboard(@Req() request: Request, @Res() response: Response) {
     const { username } = request.query;
-    const dashboard = await UserService.findOneUserDashboard(username as string);
+    const dashboard = await UserService.findOneUsernameDashboard(username as string);
     return response.json(dashboard);
   }
 
@@ -251,7 +251,8 @@ export default class UsersRouter {
       throw new Error(ERROR.PERMISSION_DENIED);
     }
     await UserService.updateOneUserDashboard(userID, request.body);
-    return response.json();
+    const dashboard = await UserService.findOneUserIDDashboard(userID);
+    return response.json({ code: RESPONSECODE.SUCCESS, data: dashboard });
   }
 
   @Delete('/:userID/follows')

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -77,6 +77,13 @@ export default class UsersRouter {
     response.clearCookie('jwt');
   }
 
+  @Get('/dashboard')
+  async getDashboard(@Req() request: Request, @Res() response: Response) {
+    const { username } = request.query;
+    const dashboard = await UserService.findOneUserDashboard(username as string);
+    return response.json(dashboard);
+  }
+
   @Get('/:userID/posts')
   async getUserPosts(@Req() request: Request, @Res() response: Response) {
     const { userID } = request.params;
@@ -151,17 +158,6 @@ export default class UsersRouter {
     const { userID } = request.params;
     const result = await NotifyService.findNotify(userID);
     return response.json({ code: RESPONSECODE.SUCCESS, data: result });
-  }
-
-  @Get('/:userID/dashboard')
-  @UseBefore(passport.authenticate('jwt-registered', { session: false }))
-  async getDashboard(@Req() request: Request, @Res() response: Response) {
-    const { userID } = request.params;
-    if (userID !== request.user?.userID) {
-      throw new Error(ERROR.PERMISSION_DENIED);
-    }
-    UserService.findOneUserDashboard(userID);
-    return response.json();
   }
 
   @Get('/:userID/tistory/:identity/posts/:postID')
@@ -245,6 +241,16 @@ export default class UsersRouter {
     }
     await UserService.updateOneUserConfig(request.user!.userID, request.body);
     return response.json({ code: RESPONSECODE.SUCCESS });
+  }
+
+  @Put('/:userID/dashboard')
+  async putDashboard(@Req() request: Request, @Res() response: Response) {
+    const { userID } = request.params;
+    if (userID !== request.user!.userID) {
+      throw new Error(ERROR.PERMISSION_DENIED);
+    }
+    await UserService.updateOneUserDashboard(userID, request.body);
+    return response.json();
   }
 
   @Delete('/:userID/follows')

--- a/backend/src/routers/v1/users.ts
+++ b/backend/src/routers/v1/users.ts
@@ -244,6 +244,7 @@ export default class UsersRouter {
   }
 
   @Put('/:userID/dashboard')
+  @UseBefore(passport.authenticate('jwt', { session: false }))
   async putDashboard(@Req() request: Request, @Res() response: Response) {
     const { userID } = request.params;
     if (userID !== request.user!.userID) {

--- a/backend/src/services/DashboardHistoryService.ts
+++ b/backend/src/services/DashboardHistoryService.ts
@@ -1,9 +1,15 @@
+import { Types } from 'mongoose';
+
 import { DashboardHistory } from 'src/models';
 
 class DashboardHistoryService {
   async createDashboardHistory(userID: string, content: string, date: string) {
     const history = await DashboardHistory.create({ userID, content, date });
     return history;
+  }
+
+  async findDashboardHistory(userID: string | Types.ObjectId) {
+    return DashboardHistory.find({ userID }).sort({ date: 1 }).lean();
   }
 
   async deleteDashboardHistory(userID: string, historyID: string) {

--- a/backend/src/services/DashboardHistoryService.ts
+++ b/backend/src/services/DashboardHistoryService.ts
@@ -1,0 +1,14 @@
+import { DashboardHistory } from 'src/models';
+
+class DashboardHistoryService {
+  async createDashboardHistory(userID: string, content: string, date: string) {
+    const history = await DashboardHistory.create({ userID, content, date });
+    return history;
+  }
+
+  async deleteDashboardHistory(userID: string, historyID: string) {
+    return DashboardHistory.deleteOne({ _id: historyID, userID });
+  }
+}
+
+export default new DashboardHistoryService();

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -121,7 +121,15 @@ class UserService {
     return result;
   }
 
-  async findOneUserDashboard(username: string) {
+  async findOneUserIDDashboard(userID: string) {
+    const userDashboard = await User.findOne({ _id: userID }, 'dashboard -_id');
+    if (!userDashboard) {
+      throw new Error(ERROR.NO_USERS);
+    }
+    return userDashboard;
+  }
+
+  async findOneUsernameDashboard(username: string) {
     const userDashboard = await User.findOne({ username }, 'dashboard -_id');
     if (!userDashboard) {
       throw new Error(ERROR.NO_USERS);
@@ -164,7 +172,7 @@ class UserService {
   }
 
   async updateOneUserDashboard(userID: string, dashboard: DashboardType) {
-    return User.updateOne({ _id: userID }, { dashboard });
+    return User.updateOne({ _id: userID }, { dashboard }, { new: true });
   }
 }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -122,7 +122,7 @@ class UserService {
   }
 
   async findOneUserDashboard(filter: object) {
-    const userDashboard = await User.findOne(filter, 'dashboard -_id');
+    const userDashboard = await User.findOne(filter, 'dashboard _id').lean();
     if (!userDashboard) {
       throw new Error(ERROR.NO_USERS);
     }

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid';
 
 import { User } from 'src/models';
-import { User as UserType, UserAuthProvider, ObjectType } from 'src/types';
+import { User as UserType, UserAuthProvider, ObjectType, DashboardType } from 'src/types';
 import { UserType as UserSchemaType } from 'src/types/modelType';
 import { ERROR, AUTH, ObjectID } from 'src/utils';
 
@@ -121,8 +121,8 @@ class UserService {
     return result;
   }
 
-  async findOneUserDashboard(userID: string) {
-    const userDashboard = await User.findOne({ _id: userID }, 'dashboard -_id');
+  async findOneUserDashboard(username: string) {
+    const userDashboard = await User.findOne({ username }, 'dashboard -_id');
     if (!userDashboard) {
       throw new Error(ERROR.NO_USERS);
     }
@@ -161,6 +161,10 @@ class UserService {
       { ...userConfig, isRegistered: true },
       { runValidators: true, upsert: true },
     );
+  }
+
+  async updateOneUserDashboard(userID: string, dashboard: DashboardType) {
+    return User.updateOne({ _id: userID }, { dashboard });
   }
 }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -121,16 +121,8 @@ class UserService {
     return result;
   }
 
-  async findOneUserIDDashboard(userID: string) {
-    const userDashboard = await User.findOne({ _id: userID }, 'dashboard -_id');
-    if (!userDashboard) {
-      throw new Error(ERROR.NO_USERS);
-    }
-    return userDashboard;
-  }
-
-  async findOneUsernameDashboard(username: string) {
-    const userDashboard = await User.findOne({ username }, 'dashboard -_id');
+  async findOneUserDashboard(filter: object) {
+    const userDashboard = await User.findOne(filter, 'dashboard -_id');
     if (!userDashboard) {
       throw new Error(ERROR.NO_USERS);
     }
@@ -172,7 +164,7 @@ class UserService {
   }
 
   async updateOneUserDashboard(userID: string, dashboard: DashboardType) {
-    return User.updateOne({ _id: userID }, { dashboard }, { new: true });
+    return User.updateOne({ _id: userID }, { dashboard }, { runValidators: true, new: true });
   }
 }
 

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -121,6 +121,14 @@ class UserService {
     return result;
   }
 
+  async findOneUserDashboard(userID: string) {
+    const userDashboard = await User.findOne({ _id: userID }, 'dashboard -_id');
+    if (!userDashboard) {
+      throw new Error(ERROR.NO_USERS);
+    }
+    return userDashboard;
+  }
+
   async updateOneUserVelogAuthentication(nanoID: string, userID: string) {
     return User.updateOne(
       { _id: userID },


### PR DESCRIPTION
### 제목
대시보드 기본 정보 가져오기, 업데이트, 사용자 연식 관련 API 추가

### 파일 변경
- backend/src/models/User.ts: 대시보드 사용 스택 mixed 에서 배열로 스키마 변경
- backend/src/routers/v1/users.ts: 대시보드 기본정보 + 연식 가져오기, 사용자 연식 추가, 대시보드 기본정보 수정, 연식 삭제 API 추가
- backend/src/services/DashboardHistoryService.ts: 사용자 연식 생성, 읽기, 삭제 service 추가
- backend/src/services/UserService.ts: 유저의 대시보드 기본정보 service 메소드 추가