### PR TITLE
포스트 width props 제거

### DIFF
--- a/frontend/src/components/DetailPost/index.tsx
+++ b/frontend/src/components/DetailPost/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import { IoCloseCircleOutline } from 'react-icons/io5';
 
@@ -10,16 +11,12 @@ import LikesButton from 'src/components/buttons/LikesButton';
 import NormalContent from 'src/components/contents/NormalContent';
 import PostComments from 'src/components/PostComments';
 import CommentInput from 'src/components/inputs/CommentInput';
-import NavigateIconButton from 'src/components/buttons/NavigateIconButton';
+import IconButton from 'src/components/buttons/IconButton';
 import { Row, Col } from 'src/components/Grid';
 
 import {
   DETAIL_POST_IMAGE_WIDTH,
   DETAIL_POST_IMAGE_HEIGHT,
-  DETAIL_COMMENT_INPUT_WIDTH,
-  DETAIL_POST_CONTENT_WIDTH,
-  DETAIL_COMMENT_ICON_SIZE,
-  DETAIL_COMMENT_ICON_PADDING,
   DETAIL_PROFILE_SET_MARGIN_LEFT,
   RETURN_BUTTON_SIZE,
 } from 'src/globals/constants';
@@ -33,6 +30,7 @@ interface Props {
 }
 
 function DetailPost({ post }: Props) {
+  const router = useRouter();
   const [comments, setComments] = useState<CommentType[]>(post.comments!);
   const [likeCount, setLikeCount] = useState(post.likes!.length);
   const handleCommentWrite = (comment: CommentType) => {
@@ -43,13 +41,16 @@ function DetailPost({ post }: Props) {
       [...prevState].filter((comment) => comment._id !== commentID),
     );
   };
+  const handleClickReturn = () => {
+    router.back();
+  };
   const { _id, images, user, likes, content } = post;
   const isImage = images!.length !== 0;
   return (
     <Wrapper isImage={isImage}>
-      <NavigateIconButton href='/home' size={RETURN_BUTTON_SIZE} plain>
+      <IconButton onClick={handleClickReturn} size={RETURN_BUTTON_SIZE} plain>
         <IoCloseCircleOutline />
-      </NavigateIconButton>
+      </IconButton>
       <ImageSection>
         <PostImages
           images={images!}
@@ -66,12 +67,12 @@ function DetailPost({ post }: Props) {
               username={user!.username!}
               marginLeft={DETAIL_PROFILE_SET_MARGIN_LEFT}
             />
-            <Row justifyContent='space-evenly'>
+            <Row>
               <LikeButton postID={_id!} postLikes={likes!} setLikeCount={setLikeCount} />
               <EchoButton postID={_id!} />
             </Row>
             {likeCount !== 0 && <LikesButton postID={post!._id!} likeCount={likeCount} />}
-            <NormalContent content={content!} width={DETAIL_POST_CONTENT_WIDTH} expanded />
+            <NormalContent content={content!} expanded />
             <PostComments
               postID={_id!}
               comments={comments}
@@ -79,13 +80,7 @@ function DetailPost({ post }: Props) {
               onCommentDelete={handleCommentDelete}
             />
           </Col>
-          <CommentInput
-            postID={_id!}
-            onCommentWrite={handleCommentWrite}
-            width={DETAIL_COMMENT_INPUT_WIDTH}
-            iconSize={DETAIL_COMMENT_ICON_SIZE}
-            padding={DETAIL_COMMENT_ICON_PADDING}
-          />
+          <CommentInput postID={_id!} onCommentWrite={handleCommentWrite} />
         </Col>
       </PostInfoSection>
     </Wrapper>

--- a/frontend/src/components/DetailPost/style.ts
+++ b/frontend/src/components/DetailPost/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import { Col } from 'src/components/Grid';
 
-import { DETAIL_POST_INFO_WIDTH } from 'src/globals/constants';
+import { POST_WIDTH } from 'src/globals/constants';
 
 interface Props {
   isImage: boolean;
@@ -25,7 +25,7 @@ const ImageSection = styled.div`
   justify-content: center;
   align-items: center;
   background: #222222;
-  width: calc(100vw - ${DETAIL_POST_INFO_WIDTH}px);
+  width: calc(100vw - ${POST_WIDTH}px);
   height: 100vh;
 `;
 
@@ -33,7 +33,7 @@ const PostInfoSection = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  width: ${DETAIL_POST_INFO_WIDTH}px;
+  width: ${POST_WIDTH}px;
   height: 100vh;
   ${Col} {
     height: 99vh;

--- a/frontend/src/components/Post/index.tsx
+++ b/frontend/src/components/Post/index.tsx
@@ -18,7 +18,7 @@ import { Row, Spacer } from 'src/components/Grid';
 
 import { CommentType, PostType } from 'src/types';
 
-import { POST_CARD_WIDTH } from 'src/globals/constants';
+import { POST_WIDTH } from 'src/globals/constants';
 
 import userAtom from 'src/recoil/user';
 
@@ -44,7 +44,7 @@ function Post({ post, onPostDelete }: Props) {
   const isMe = me._id !== user!._id;
 
   return (
-    <CardCommon width={POST_CARD_WIDTH}>
+    <CardCommon width={POST_WIDTH}>
       <Row alignItems='center'>
         <ProfileSet profileImage={user!.profileImage} username={user!.username!} />
         <TimeFromNow time={createdAt!} />

--- a/frontend/src/components/TimeFromNow/style.ts
+++ b/frontend/src/components/TimeFromNow/style.ts
@@ -1,8 +1,11 @@
 import styled from '@emotion/styled';
 
+import { TIME_MIN_WIDTH } from 'src/globals/constants';
+
 const Time = styled.p`
   color: #aaaaaa;
   font-size: 13px;
+  min-width: ${TIME_MIN_WIDTH}px;
 `;
 
 // eslint-disable-next-line import/prefer-default-export

--- a/frontend/src/components/contents/BaekjoonContent/index.tsx
+++ b/frontend/src/components/contents/BaekjoonContent/index.tsx
@@ -2,26 +2,21 @@ import PropTypes from 'prop-types';
 
 import ContentCommon from 'src/components/contents/Common';
 
-import { DEFAULT_POST_CONTENT_WIDTH } from 'src/globals/constants';
-
 interface Props {
   content: string;
-  width?: number;
   expanded?: boolean;
 }
 
-function BaekjoonContent({ content, width, expanded }: Props) {
-  return <ContentCommon content={content} width={width} expanded={expanded} />;
+function BaekjoonContent({ content, expanded }: Props) {
+  return <ContentCommon content={content} expanded={expanded} />;
 }
 
 BaekjoonContent.propTypes = {
   content: PropTypes.string.isRequired,
-  width: PropTypes.number,
   expanded: PropTypes.bool,
 };
 
 BaekjoonContent.defaultProps = {
-  width: DEFAULT_POST_CONTENT_WIDTH,
   expanded: false,
 };
 

--- a/frontend/src/components/contents/BlogContent/index.tsx
+++ b/frontend/src/components/contents/BlogContent/index.tsx
@@ -2,26 +2,21 @@ import PropTypes from 'prop-types';
 
 import ContentCommon from 'src/components/contents/Common';
 
-import { DEFAULT_POST_CONTENT_WIDTH } from 'src/globals/constants';
-
 interface Props {
   content: string;
-  width?: number;
   expanded?: boolean;
 }
 
-function BlogContent({ content, width, expanded }: Props) {
-  return <ContentCommon content={content} width={width} expanded={expanded} />;
+function BlogContent({ content, expanded }: Props) {
+  return <ContentCommon content={content} expanded={expanded} />;
 }
 
 BlogContent.propTypes = {
   content: PropTypes.string.isRequired,
-  width: PropTypes.number,
   expanded: PropTypes.bool,
 };
 
 BlogContent.defaultProps = {
-  width: DEFAULT_POST_CONTENT_WIDTH,
   expanded: false,
 };
 

--- a/frontend/src/components/contents/Common/index.tsx
+++ b/frontend/src/components/contents/Common/index.tsx
@@ -3,17 +3,16 @@ import PropTypes from 'prop-types';
 
 import ButtonCommon from 'src/components/buttons/Common';
 
-import { POST_CONTENT_LIMIT_LENGTH, DEFAULT_POST_CONTENT_WIDTH } from 'src/globals/constants';
+import { POST_CONTENT_LIMIT_LENGTH } from 'src/globals/constants';
 
 import { Wrapper, Content } from './style';
 
 interface Props {
   content: string;
-  width?: number;
   expanded?: boolean;
 }
 
-function ContentCommon({ content, width, expanded }: Props) {
+function ContentCommon({ content, expanded }: Props) {
   const [isExpand, setIsExpand] = useState(expanded);
   const isShort = content.length < POST_CONTENT_LIMIT_LENGTH;
   const shortContent = content.substr(0, POST_CONTENT_LIMIT_LENGTH);
@@ -22,17 +21,17 @@ function ContentCommon({ content, width, expanded }: Props) {
   };
   if (isShort) {
     return (
-      <Wrapper width={width!}>
+      <Wrapper>
         <Content>{shortContent}</Content>
       </Wrapper>
     );
   }
   return isExpand ? (
-    <Wrapper width={width!}>
+    <Wrapper>
       <Content>{content}</Content>
     </Wrapper>
   ) : (
-    <Wrapper width={width!}>
+    <Wrapper>
       <Content>{shortContent}</Content>
       <ButtonCommon onClick={handleClick}>더보기</ButtonCommon>
     </Wrapper>
@@ -41,12 +40,10 @@ function ContentCommon({ content, width, expanded }: Props) {
 
 ContentCommon.propTypes = {
   content: PropTypes.string.isRequired,
-  width: PropTypes.number,
   expanded: PropTypes.bool,
 };
 
 ContentCommon.defaultProps = {
-  width: DEFAULT_POST_CONTENT_WIDTH,
   expanded: false,
 };
 

--- a/frontend/src/components/contents/Common/style.ts
+++ b/frontend/src/components/contents/Common/style.ts
@@ -1,12 +1,10 @@
 import styled from '@emotion/styled';
 
-interface Props {
-  width: number;
-}
+import { POST_CONTENT_WIDTH } from 'src/globals/constants';
 
-const Wrapper = styled.div<Props>`
+const Wrapper = styled.div`
   margin: 16px;
-  width: ${({ width }) => `${width}px`};
+  width: ${POST_CONTENT_WIDTH};
 `;
 
 const Content = styled.p`

--- a/frontend/src/components/contents/GitHubContent/index.tsx
+++ b/frontend/src/components/contents/GitHubContent/index.tsx
@@ -2,26 +2,21 @@ import PropTypes from 'prop-types';
 
 import ContentCommon from 'src/components/contents/Common';
 
-import { DEFAULT_POST_CONTENT_WIDTH } from 'src/globals/constants';
-
 interface Props {
   content: string;
-  width?: number;
   expanded?: boolean;
 }
 
-function GitHubContent({ content, width, expanded }: Props) {
-  return <ContentCommon content={content} width={width} expanded={expanded} />;
+function GitHubContent({ content, expanded }: Props) {
+  return <ContentCommon content={content} expanded={expanded} />;
 }
 
 GitHubContent.propTypes = {
   content: PropTypes.string.isRequired,
-  width: PropTypes.number,
   expanded: PropTypes.bool,
 };
 
 GitHubContent.defaultProps = {
-  width: DEFAULT_POST_CONTENT_WIDTH,
   expanded: false,
 };
 

--- a/frontend/src/components/contents/NormalContent/index.tsx
+++ b/frontend/src/components/contents/NormalContent/index.tsx
@@ -2,26 +2,21 @@ import PropTypes from 'prop-types';
 
 import ContentCommon from 'src/components/contents/Common';
 
-import { DEFAULT_POST_CONTENT_WIDTH } from 'src/globals/constants';
-
 interface Props {
   content: string;
-  width?: number;
   expanded?: boolean;
 }
 
-function NormalContent({ content, width, expanded }: Props) {
-  return <ContentCommon content={content} width={width} expanded={expanded} />;
+function NormalContent({ content, expanded }: Props) {
+  return <ContentCommon content={content} expanded={expanded} />;
 }
 
 NormalContent.propTypes = {
   content: PropTypes.string.isRequired,
-  width: PropTypes.number,
   expanded: PropTypes.bool,
 };
 
 NormalContent.defaultProps = {
-  width: DEFAULT_POST_CONTENT_WIDTH,
   expanded: false,
 };
 

--- a/frontend/src/globals/constants.ts
+++ b/frontend/src/globals/constants.ts
@@ -87,8 +87,6 @@ export const POST_CONTENT_LIMIT_LENGTH = 100;
 
 export const POST_CONTENT_WIDTH = 575;
 
-export const POST_COMMENT_CONTENT_WIDTH = 330;
-
 // MODAL
 export const DELETE_MODAL_TITLE_HEIGHT = 50;
 

--- a/frontend/src/globals/constants.ts
+++ b/frontend/src/globals/constants.ts
@@ -64,20 +64,12 @@ export const SOCIAL_ICON_SIZE = 48;
 
 export const DEFAULT_ICON_SIZE = 24;
 
-export const DETAIL_COMMENT_ICON_SIZE = 18;
-
-export const DETAIL_COMMENT_ICON_PADDING = 12;
-
 // INPUT
 export const SEARCH_INPUT_WIDTH = 136;
 
 export const DEFAULT_COMMENT_INPUT_WIDTH = 340;
 
-export const DETAIL_COMMENT_INPUT_WIDTH = 200;
-
 // CARD
-export const POST_CARD_WIDTH = 600;
-
 export const SIGNIN_CARD_WIDTH = 500;
 
 export const SUGGESTION_CARD_WIDTH = 800;
@@ -89,13 +81,14 @@ export const USER_SETTING_CARD_WIDTH = 600;
 export const EXTERNAL_AUTH_CARD_WIDTH = 600;
 
 // POST
+export const POST_WIDTH = 600;
+
 export const POST_CONTENT_LIMIT_LENGTH = 100;
 
-export const DEFAULT_POST_CONTENT_WIDTH = 575;
+export const POST_CONTENT_WIDTH = 575;
 
-export const DETAIL_POST_CONTENT_WIDTH = 350;
+export const POST_COMMENT_CONTENT_WIDTH = 330;
 
-export const DETAIL_POST_INFO_WIDTH = 410;
 // MODAL
 export const DELETE_MODAL_TITLE_HEIGHT = 50;
 
@@ -106,3 +99,6 @@ export const SUGGESTION_COUNT = 3;
 
 // MODAL
 export const REPOS_MODAL_HEIGHT = 500;
+
+// TIME
+export const TIME_MIN_WIDTH = 60;


### PR DESCRIPTION
### 제목
- 포스트 width props 제거
- TimeFromNow 컴포넌트 min-width 추가
- 포스트 전체보기 취소 버튼 

### 파일 변경
- frontend/src/components/DetailPost/index.tsx : 취소 버튼 router.back으로 변경
- frontend/src/components/DetailPost/style.ts : 전체보기 width timeline과 동일하게 부여
- frontend/src/components/Post/index.tsx : 상수 명 변경
- frontend/src/components/TimeFromNow/style.ts : min-width 추가
- frontend/src/components/contents/BaekjoonContent/index.tsx : width Props 제거
- frontend/src/components/contents/BlogContent/index.tsx : width Props 제거
- frontend/src/components/contents/Common/index.tsx : width Props 제거
- frontend/src/components/contents/Common/style.ts : width Props 제거
- frontend/src/components/contents/GitHubContent/index.tsx : width Props 제거
- frontend/src/components/contents/NormalContent/index.tsx : width Props 제거
- frontend/src/globals/constants.ts : 상수 수정
