### PR TITLE
블로그, 레포 컨텐트 컴포넌트 잡기

### DIFF
--- a/frontend/src/components/contents/BlogContent/index.tsx
+++ b/frontend/src/components/contents/BlogContent/index.tsx
@@ -1,23 +1,27 @@
 import PropTypes from 'prop-types';
-
-import ContentCommon from 'src/components/contents/Common';
+import dompurify from 'dompurify';
 
 interface Props {
   content: string;
-  expanded?: boolean;
+  link: string;
 }
 
-function BlogContent({ content, expanded }: Props) {
-  return <ContentCommon content={content} expanded={expanded} />;
+function BlogContent({ content, link }: Props) {
+  const sanitizer = dompurify.sanitize;
+  return (
+    <>
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: sanitizer(content) }} />
+      <a target='_blank' href={link} rel='noreferrer noopener'>
+        글 보러가기
+      </a>
+    </>
+  );
 }
 
 BlogContent.propTypes = {
   content: PropTypes.string.isRequired,
-  expanded: PropTypes.bool,
-};
-
-BlogContent.defaultProps = {
-  expanded: false,
+  link: PropTypes.string.isRequired,
 };
 
 export default BlogContent;

--- a/frontend/src/components/contents/ExternalContent/index.tsx
+++ b/frontend/src/components/contents/ExternalContent/index.tsx
@@ -4,7 +4,7 @@ import RepoContent from 'src/components/contents/RepoContent';
 import BlogContent from 'src/components/contents/BlogContent';
 import ProblemContent from 'src/components/contents/ProblemContent';
 
-import { ExternalType, ProblemInfoType } from 'src/types';
+import { ExternalType, ProblemInfoType, RepoInfoType } from 'src/types';
 
 import { Wrapper, Cover, MoreButton, LinkButton } from './style';
 
@@ -24,12 +24,17 @@ function ExternalContent({ external }: Props) {
       <Cover hidden={isExpand} />
       {!isExpand && <MoreButton onClick={handleMoreClick}>더보기</MoreButton>}
       {!isExpand && (
-        <LinkButton onClick={handleLinkClick} href={external.link} target='_blank'>
+        <LinkButton
+          onClick={handleLinkClick}
+          href={external.link}
+          target='_blank'
+          rel='noreferrer noopener'
+        >
           바로가기
         </LinkButton>
       )}
       {(() => {
-        if (external.type === 'algorithm') {
+        if (external.type === 'problem') {
           return (
             <ProblemContent
               content={external.content}
@@ -38,11 +43,17 @@ function ExternalContent({ external }: Props) {
             />
           );
         }
-        if (external.type === 'github') {
-          return <RepoContent content={external.content} />;
+        if (external.type === 'repository') {
+          return (
+            <RepoContent
+              content={external.content}
+              info={external.info! as RepoInfoType}
+              link={external.link}
+            />
+          );
         }
         if (external.type === 'tistory') {
-          return <BlogContent content={external.content} />;
+          return <BlogContent content={external.content} link={external.link} />;
         }
         return null;
       })()}

--- a/frontend/src/components/contents/ProblemContent/index.tsx
+++ b/frontend/src/components/contents/ProblemContent/index.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import dompurify from 'dompurify';
 
 import { Row } from 'src/components/Grid';
+
 import { ProblemInfoType } from 'src/types';
 
 interface Props {

--- a/frontend/src/components/contents/ProblemContent/index.tsx
+++ b/frontend/src/components/contents/ProblemContent/index.tsx
@@ -15,14 +15,14 @@ function ProblemContent({ content, info, link }: Props) {
   const sanitizer = dompurify.sanitize;
   return (
     <>
-      <Row justifyContent='space-between' padding={16}>
+      <Row justifyContent='space-between'>
         <p>티어 {info.tear}</p>
         <p>푼 사람 {info.solvedUserCount}</p>
         <p>시도 횟수 {info.totalTryCount}</p>
       </Row>
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: sanitizer(content) }} />
-      <a target='_blank' href={link} rel='noreferrer'>
+      <a target='_blank' href={link} rel='noreferrer noopener'>
         문제 보러가기
       </a>
     </>

--- a/frontend/src/components/contents/RepoContent/index.tsx
+++ b/frontend/src/components/contents/RepoContent/index.tsx
@@ -1,15 +1,43 @@
 import PropTypes from 'prop-types';
+import dompurify from 'dompurify';
+
+import { Row, Col } from 'src/components/Grid';
+
+import { RepoInfoType } from 'src/types';
 
 interface Props {
   content: string;
+  link: string;
+  info: RepoInfoType;
 }
 
-function RepoContent({ content }: Props) {
-  return <>todo</>;
+function RepoContent({ content, link, info }: Props) {
+  const sanitizer = dompurify.sanitize;
+  return (
+    <>
+      <Row justifyContent='space-between'>
+        <p>별 {info.starCount}</p>
+        <p>포크 {info.forkCount}</p>
+        {Object.keys(info.language).map((language) => (
+          <Col>
+            <p>{language}</p>
+            <p>{info.language[language]}%</p>
+          </Col>
+        ))}
+      </Row>
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: sanitizer(content) }} />
+      <a target='_blank' href={link} rel='noreferrer noopener'>
+        글 보러가기
+      </a>
+    </>
+  );
 }
 
 RepoContent.propTypes = {
   content: PropTypes.string.isRequired,
+  info: PropTypes.objectOf(PropTypes.any).isRequired,
+  link: PropTypes.string.isRequired,
 };
 
 export default RepoContent;

--- a/frontend/src/components/contents/RepoContent/index.tsx
+++ b/frontend/src/components/contents/RepoContent/index.tsx
@@ -19,7 +19,7 @@ function RepoContent({ content, link, info }: Props) {
         <p>별 {info.starCount}</p>
         <p>포크 {info.forkCount}</p>
         {Object.keys(info.language).map((language) => (
-          <Col>
+          <Col key={language}>
             <p>{language}</p>
             <p>{info.language[language]}%</p>
           </Col>

--- a/frontend/src/types/external.ts
+++ b/frontend/src/types/external.ts
@@ -4,7 +4,7 @@ export default interface ExternalType {
   content: string;
   link: string;
   info?: RepoInfoType | ProblemInfoType;
-  type: 'github' | 'tistory' | 'velog' | 'algorithm';
+  type: 'repository' | 'tistory' | 'velog' | 'problem';
   identity: string;
   target: string;
 }

--- a/frontend/src/types/info.ts
+++ b/frontend/src/types/info.ts
@@ -7,5 +7,5 @@ export interface ProblemInfoType {
 export interface RepoInfoType {
   forkCount: number;
   starCount: string;
-  // @TODO 추가 예정
+  language: any;
 }


### PR DESCRIPTION
전체적으로 스타일링은 미완료 입니다.
양해바랍니다~~ 

그리고 a 태그 관련 변경 사항을 읽기 전에 아래 글을 추천드립니다.
https://joshua-dev-story.blogspot.com/2020/12/html-rel-noopener-noreferrer.html


### 파일 변경
- frontend/src/components/contents/BlogContent/index.tsx: 블로그 컨텐트 개발 완료
- frontend/src/components/contents/ExternalContent/index.tsx: 외부 컨텐트에서 변경에 맞게 수정
- frontend/src/components/contents/ProblemContent/index.tsx: 매직 넘버 제거 a 태그에 noopener 추가
- frontend/src/components/contents/RepoContent/index.tsx: 레포 컨텐트 개발 완료
- frontend/src/types/external.ts: 외부 타입 최신 API에 맞게 수정
- frontend/src/types/info.ts: 레포 인포 타입에 언어 추가