### PR TITLE
비회원으로 접속할 경우 레이아웃 예외 처리

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -13,7 +13,7 @@ import LogoButton from 'src/components/buttons/LogoButton';
 import IconButton from 'src/components/buttons/IconButton';
 import SearchInput from 'src/components/inputs/SearchInput';
 
-import userAtom from 'src/recoil/user';
+import userAtom, { isAuthenticatedSelector } from 'src/recoil/user';
 
 import { Wrapper, Section } from './style';
 
@@ -23,6 +23,7 @@ interface Props {
 
 function Header({ page }: Props) {
   const user = useRecoilValue(userAtom);
+  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
 
   return (
     <Wrapper>
@@ -44,12 +45,16 @@ function Header({ page }: Props) {
       </Section>
 
       <Section>
-        <IconButton>
-          <IoHeartOutline />
-        </IconButton>
-        <NavigateIconButton href={`/users/${user.username}`} clicked={page === 'username'}>
-          <IoPersonCircleOutline />
-        </NavigateIconButton>
+        {isAuthenticated && (
+          <>
+            <IconButton>
+              <IoHeartOutline />
+            </IconButton>
+            <NavigateIconButton href={`/users/${user.username}`} clicked={page === 'username'}>
+              <IoPersonCircleOutline />
+            </NavigateIconButton>
+          </>
+        )}
       </Section>
     </Wrapper>
   );

--- a/frontend/src/components/Post/index.tsx
+++ b/frontend/src/components/Post/index.tsx
@@ -43,6 +43,7 @@ function Post({ post, onPostDelete }: Props) {
   };
   const { _id, user, images, content, likes, createdAt, type, external } = post;
   const isMe = me._id !== user!._id;
+
   return (
     <CardCommon width={POST_WIDTH}>
       <Row alignItems='center'>

--- a/frontend/src/components/inputs/CommentInput/index.tsx
+++ b/frontend/src/components/inputs/CommentInput/index.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_ICON_SIZE,
 } from 'src/globals/constants';
 
-import userAtom from 'src/recoil/user';
+import userAtom, { isAuthenticatedSelector } from 'src/recoil/user';
 
 import { CommentType } from 'src/types';
 
@@ -31,8 +31,11 @@ interface Props {
 }
 
 function CommentInput({ postID, onCommentWrite, width, iconSize, padding }: Props) {
-  const [value, setValue] = useState('');
   const user = useRecoilValue(userAtom);
+  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
+
+  const [value, setValue] = useState('');
+  const placeholder = isAuthenticated ? '' : '댓글을 남기려면 인증이 필요합니다.';
   const postPostComment = () => Fetcher.postPostComment(user, postID, value);
   const mutation = useMutation(postPostComment, {
     onSuccess: ({ data }) => onCommentWrite(data!),
@@ -46,7 +49,12 @@ function CommentInput({ postID, onCommentWrite, width, iconSize, padding }: Prop
   return (
     <Row justifyContent='center' alignItems='center'>
       <ProfileImage profileImage={user.profileImage} />
-      <InputCommon bind={[value, setValue]} width={width} icon={<BiComment />} />
+      <InputCommon
+        bind={[value, setValue]}
+        width={width}
+        icon={<BiComment />}
+        placeholder={placeholder}
+      />
       <IconButton onClick={handleClick} size={iconSize!} padding={padding!}>
         <BiSend />
       </IconButton>

--- a/frontend/src/components/modals/SigninModal/index.tsx
+++ b/frontend/src/components/modals/SigninModal/index.tsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+import Google from 'src/components/buttons/socials/Google';
+import Github from 'src/components/buttons/socials/Github';
+import Kakao from 'src/components/buttons/socials/Kakao';
+import ModalCommon from 'src/components/modals/Common';
+import { Row } from 'src/components/Grid';
+
+interface Props {
+  onClose: () => void;
+}
+
+function SigninModal({ onClose }: Props) {
+  return (
+    <ModalCommon close='취소' onClose={onClose}>
+      <Row justifyContent='center'>
+        <Google />
+        <Github />
+        <Kakao />
+      </Row>
+    </ModalCommon>
+  );
+}
+
+SigninModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+
+export default SigninModal;

--- a/frontend/src/components/modals/UsersModal/index.tsx
+++ b/frontend/src/components/modals/UsersModal/index.tsx
@@ -21,7 +21,11 @@ function UsersModal({ title, users, onClose }: Props) {
       <Col>
         {users?.map((user) => (
           <Row justifyContent='space-between' key={user._id}>
-            <ProfileSet profileImage={user.profileImage} username={user.username!} />
+            <ProfileSet
+              profileImage={user.profileImage}
+              username={user.username!}
+              onClick={onClose}
+            />
             <FollowSet targetUserID={user._id!} />
           </Row>
         ))}

--- a/frontend/src/components/sets/FollowSet/index.tsx
+++ b/frontend/src/components/sets/FollowSet/index.tsx
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types';
 import UnfollowButton from 'src/components/buttons/UnfollowButton';
 import FollowButton from 'src/components/buttons/FollowButton';
 
-import userAtom, { followersSelector, followsSelector } from 'src/recoil/user';
+import userAtom, {
+  followersSelector,
+  followsSelector,
+  isAuthenticatedSelector,
+} from 'src/recoil/user';
 
 interface Props {
   targetUserID: string;
@@ -15,6 +19,7 @@ interface Props {
 
 function FollowSet({ targetUserID, onFollow, onUnfollow }: Props) {
   const user = useRecoilValue(userAtom);
+  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
   const followers = useRecoilValue(followersSelector);
   const [follows, setFollows] = useRecoilState<string[]>(followsSelector);
 
@@ -31,7 +36,7 @@ function FollowSet({ targetUserID, onFollow, onUnfollow }: Props) {
     setFollows((prevState) => prevState.filter((id) => id !== targetUserID));
     onUnfollow();
   }, [onUnfollow, setFollows, targetUserID]);
-  if (isMe) {
+  if (isMe || !isAuthenticated) {
     return null;
   }
   return isFollow ? (

--- a/frontend/src/components/sets/ProfileSet/index.tsx
+++ b/frontend/src/components/sets/ProfileSet/index.tsx
@@ -15,11 +15,12 @@ interface Props {
   profileImage?: string;
   username: string;
   marginLeft?: number;
+  onClick: () => void;
 }
 
-function ProfileSet({ profileImage, username, marginLeft }: Props) {
+function ProfileSet({ profileImage, username, marginLeft, onClick }: Props) {
   return (
-    <Wrapper marginLeft={marginLeft!}>
+    <Wrapper marginLeft={marginLeft!} onClick={onClick}>
       <ProfileImageButton
         profileImage={profileImage!}
         username={username}
@@ -34,11 +35,13 @@ ProfileSet.propTypes = {
   profileImage: PropTypes.string,
   username: PropTypes.string.isRequired,
   marginLeft: PropTypes.number,
+  onClick: PropTypes.func,
 };
 
 ProfileSet.defaultProps = {
   profileImage: DEFAULT_PROFILE_IMAGE,
   marginLeft: 0,
+  onClick: () => {},
 };
 
 export default ProfileSet;

--- a/frontend/src/pages/users/[username].tsx
+++ b/frontend/src/pages/users/[username].tsx
@@ -7,6 +7,7 @@ import Timeline from 'src/components/Timeline';
 import UserInfoCard from 'src/components/cards/UserInfoCard';
 import FloatingButton from 'src/components/buttons/FloatingButton';
 import LoadingIndicator from 'src/components/LoadingIndicator';
+import SigninCard from 'src/components/cards/SigninCard';
 import { Col } from 'src/components/Grid';
 
 import { UserType } from 'src/types';
@@ -25,6 +26,7 @@ interface Props {
 }
 
 function User({ targetUser }: Props) {
+  const isAuthenticated = useRecoilValue(isRegisteredSelector);
   const isUserExist = Object.keys(targetUser).length !== 0;
   const isRegistered = useRecoilValue(isRegisteredSelector);
   const { refetch, data } = useInfiniteQuery(
@@ -51,6 +53,7 @@ function User({ targetUser }: Props) {
       <Page.Main>
         <LoadingIndicator />
         <Col alignItems='center'>
+          {!isAuthenticated && <SigninCard />}
           {isUserExist ? (
             <>
               <UserInfoCard targetUser={targetUser} />
@@ -69,14 +72,6 @@ function User({ targetUser }: Props) {
 export async function getServerSideProps(context: any) {
   const { username } = context.query;
   const token = context.req?.cookies.jwt;
-  if (token === undefined) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: '/',
-      },
-    };
-  }
   const targetUser = await Fetcher.getUsersByUsername(token, username);
   return {
     props: { targetUser },

--- a/frontend/src/utils/moment.ts
+++ b/frontend/src/utils/moment.ts
@@ -27,7 +27,7 @@ const getFromNow = (time: string) => {
   if (interval > 1) {
     return `${Math.floor(interval)}분 전`;
   }
-  return `${Math.floor(seconds)}초 전`;
+  return '방금';
 };
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
일괄 수정및 리팩토링이라 양이 좀 됩니다..

### 한 일
- users/:username에서 비회원 열람 기능이 지원됩니다.
- UsersModal에서 사람 누를 시 모달 안사라지던 버그 수정
- 인증 모달 개발
- 임시 방편으로 비회원 게시글 좋아요 막음 (인증 모달 띄움) 해당 부분은 Auth 전용 버튼으로 추상화 예정


### 할 일
- Auth 전용 버튼을 추상화
- 로그인 완료 후 리다이렉트 시 이전의 행동을 기억하기

### 파일 변경
- frontend/src/pages/users/[username].tsx: 비회원 users/:username 열람가능
- frontend/src/utils/moment.ts: 몇초 전은 너무 짧은 기간이어서 초 단위는 방금으로 변경
- frontend/src/components/sets/ProfileSet/index.tsx: ProfileSet에 onClick 이벤트 받기
- frontend/src/components/sets/FollowSet/index.tsx: FollowSet에서 인증을 하지 않을 시 null 리턴
- frontend/src/components/modals/UsersModal/index.tsx: 유저스 모달이 안사라지던 버그 수정
- frontend/src/components/modals/SigninModal/index.tsx: 인증 모달 개발
- frontend/src/components/inputs/CommentInput/index.tsx: 인증을 안할 시 댓글 placeholder에 인증하라고 말함
- frontend/src/components/buttons/LikeButton/index.tsx: 좋아요 버튼에 임시방편으로 비회원 처리
- frontend/src/components/Post/index.tsx: 공백 리팩토링
- frontend/src/components/Header/index.tsx: 비회원일 시 헤더 우측 섹션 안보이도록 변경