### PR TITLE
외부 연동 작성 잡기1

### DIFF
--- a/frontend/src/components/buttons/Common/index.tsx
+++ b/frontend/src/components/buttons/Common/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   children: ReactNode;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   clicked?: boolean;
+  disabled?: boolean;
 }
 
 function ButtonCommon({
@@ -27,6 +28,7 @@ function ButtonCommon({
   plain,
   hidden,
   clicked,
+  disabled,
 }: Props) {
   return (
     <Button
@@ -38,6 +40,7 @@ function ButtonCommon({
       plain={plain!}
       hidden={hidden!}
       clicked={clicked!}
+      disabled={disabled!}
     >
       {children}
     </Button>
@@ -54,6 +57,7 @@ ButtonCommon.propsType = {
   hidden: PropTypes.bool,
   onClick: PropTypes.func,
   clicked: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 ButtonCommon.defaultProps = {
@@ -65,6 +69,7 @@ ButtonCommon.defaultProps = {
   plain: false,
   onClick: () => {},
   clicked: false,
+  disabled: false,
 };
 
 export default ButtonCommon;

--- a/frontend/src/components/buttons/Common/style.ts
+++ b/frontend/src/components/buttons/Common/style.ts
@@ -10,6 +10,7 @@ interface Props {
   plain: boolean;
   hidden: boolean;
   clicked: boolean;
+  disabled: boolean;
 }
 
 const Button = styled.button<Props>`
@@ -21,11 +22,11 @@ const Button = styled.button<Props>`
   margin: ${({ margin }) => (margin ? `${margin}px` : 0)};
   padding: ${({ padding }) => (padding ? `${padding}px` : 0)};
   border-radius: 50px;
-  box-shadow: ${({ clicked, plain }) => {
+  box-shadow: ${({ clicked, disabled, plain }) => {
     if (clicked) {
       return 'inset 4px 4px 8px #3a3a3a, inset -4px -4px 8px #4e4e4e;';
     }
-    if (plain) {
+    if (plain || disabled) {
       return 'unset';
     }
     return '5px 5px 10px #3a3a3a, -5px -5px 10px #4e4e4e';

--- a/frontend/src/components/cards/ExternalAuthCard/index.tsx
+++ b/frontend/src/components/cards/ExternalAuthCard/index.tsx
@@ -1,16 +1,30 @@
+import { useRecoilValue } from 'recoil';
+
 import CardCommon from 'src/components/cards/Common';
 import ButtonCommon from 'src/components/buttons/Common';
 import { Row } from 'src/components/Grid';
 
 import { EXTERNAL_AUTH_CARD_WIDTH } from 'src/globals/constants';
 
+import userAtom from 'src/recoil/user';
+
+const url = process.env.NEXT_PUBLIC_SERVER_URL as string;
+
 function ExternalAuthCard() {
-  const handleClickGithub = () => {};
+  const user = useRecoilValue(userAtom);
+  const handleClickGithub = () => {
+    window.open(`${url}/v1/socials/github?user_id=${user._id}`, '_self');
+  };
+
+  const handleClickBlog = () => {
+    window.open(`${url}/v1/socials/github?user_id=${user._id}`, '_self');
+  };
 
   return (
     <CardCommon width={EXTERNAL_AUTH_CARD_WIDTH}>
       <Row justifyContent='center'>
         <ButtonCommon onClick={handleClickGithub}>깃허브 연동하기</ButtonCommon>
+        <ButtonCommon onClick={handleClickBlog}>블로그 연동하기</ButtonCommon>
       </Row>
     </CardCommon>
   );

--- a/frontend/src/components/inputs/ImageInput/index.tsx
+++ b/frontend/src/components/inputs/ImageInput/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 function ImageInput({ onImageUpload, children }: Props) {
-  const handleOnChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files!);
     // eslint-disable-next-line no-param-reassign
     event.target.value = '';
@@ -28,7 +28,7 @@ function ImageInput({ onImageUpload, children }: Props) {
         id='image'
         type='file'
         accept='image/jpg,image/png,image/jpeg,image/gif'
-        onChange={handleOnChange}
+        onChange={handleChange}
         multiple
       />
     </label>

--- a/frontend/src/components/modals/Common/index.tsx
+++ b/frontend/src/components/modals/Common/index.tsx
@@ -13,9 +13,10 @@ interface Props {
   close?: string;
   confirm?: string;
   height?: number;
+  disabled?: boolean;
 }
 
-function ModalCommon({ children, onClose, onConfirm, close, confirm, height }: Props) {
+function ModalCommon({ children, onClose, onConfirm, close, confirm, height, disabled }: Props) {
   return (
     <>
       <Background onClick={onClose} />
@@ -25,7 +26,11 @@ function ModalCommon({ children, onClose, onConfirm, close, confirm, height }: P
           <Row>
             <Spacer />
             {close !== '' && <ButtonCommon onClick={onClose}>{close}</ButtonCommon>}
-            {confirm !== '' && <ButtonCommon onClick={onConfirm}>{confirm}</ButtonCommon>}
+            {confirm !== '' && (
+              <ButtonCommon onClick={onConfirm} disabled={disabled}>
+                {confirm}
+              </ButtonCommon>
+            )}
           </Row>
         </Col>
       </Card>
@@ -40,6 +45,7 @@ ModalCommon.propTyps = {
   close: PropTypes.string,
   confirm: PropTypes.string,
   height: PropTypes.number,
+  disabled: PropTypes.bool,
 };
 
 ModalCommon.defaultProps = {
@@ -48,6 +54,7 @@ ModalCommon.defaultProps = {
   close: '',
   confirm: '',
   height: 0,
+  disabled: false,
 };
 
 export default ModalCommon;

--- a/frontend/src/components/modals/PostWriteModal/index.tsx
+++ b/frontend/src/components/modals/PostWriteModal/index.tsx
@@ -16,6 +16,8 @@ import { Fetcher } from 'src/utils';
 
 import userAtom from 'src/recoil/user';
 
+import { ProblemType, RepoType } from 'src/types';
+
 import { Textarea, IconHolder } from './style';
 
 interface Props {
@@ -58,26 +60,27 @@ function PostWriteModal({ onClose, onPostWrite }: Props) {
     setImages((prevState) => prevState.filter((image, i) => i !== index));
   }, []);
 
-  const handleClickGithub = () => {
-    setIsReposModalShow(true);
-  };
-
-  const handleClickProblems = () => {
-    setIsProblemsModalShow(true);
-  };
-
-  const handleReposModalClose = () => {
+  const handleClickGithub = () => setIsReposModalShow(true);
+  const handleClickProblems = () => setIsProblemsModalShow(true);
+  const handleReposModalClose = () => setIsReposModalShow(false);
+  const handleProblemsModalClose = () => setIsProblemsModalShow(false);
+  const handleRepoSelect = (repo: RepoType) => {
+    console.log(repo);
     setIsReposModalShow(false);
   };
-
-  const handleProblemsModalClose = () => {
+  const handleProblemSelect = (problem: ProblemType) => {
+    console.log(problem);
     setIsProblemsModalShow(false);
   };
 
   return (
     <>
-      {isReposModalShow && <ReposModal onClose={handleReposModalClose} />}
-      {isProblemsModalShow && <ProblemsModal onClose={handleProblemsModalClose} />}
+      {isReposModalShow && (
+        <ReposModal onClose={handleReposModalClose} onSelect={handleRepoSelect} />
+      )}
+      {isProblemsModalShow && (
+        <ProblemsModal onClose={handleProblemsModalClose} onSelect={handleProblemSelect} />
+      )}
       <ModalCommon close='취소' confirm='확인' onConfirm={handleConfirm} onClose={onClose}>
         <Row justifyContent='center' alignItems='center' margin={16}>
           <ImageInput onImageUpload={handleImageUpload}>

--- a/frontend/src/components/modals/ProblemsModal/index.tsx
+++ b/frontend/src/components/modals/ProblemsModal/index.tsx
@@ -9,58 +9,65 @@ import { Col, Row } from 'src/components/Grid';
 
 import { Fetcher } from 'src/utils';
 
-import { PROBLEM_BUTTON_WIDTH, PROBLEMS_MODAL_HEIGHT } from 'src/globals/constants';
+import { PROBLEMS_MODAL_HEIGHT } from 'src/globals/constants';
 
-import { Wrapper, Problem, Title } from './style';
+import { ProblemType } from 'src/types';
+
+import { Wrapper, Problems, Title } from './style';
 
 interface Props {
+  // eslint-disable-next-line no-unused-vars
+  onSelect: (problem: ProblemType) => void;
   onClose: () => void;
 }
 
-function ProblemsModal({ onClose }: Props) {
-  const [clickedIndex, setClickedIndex] = useState(-1);
+function ProblemsModal({ onClose, onSelect }: Props) {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
   const [query, setQuery] = useState('');
-  const { mutate, data } = useMutation(() => Fetcher.getProblemSearch(query));
+  const { mutate, data: problems, isLoading } = useMutation(() => Fetcher.getProblemSearch(query));
   const handleSearchClick = () => {
     mutate();
   };
-  const handleProblemClick = (index: number) => {
-    setClickedIndex(index);
-  };
 
   const handleConfirm = () => {
-    onClose();
+    onSelect(problems![selectedIndex]);
+  };
+
+  const handleProblemClick = (index: number) => {
+    if (index === selectedIndex) {
+      setSelectedIndex(-1);
+    } else {
+      setSelectedIndex(index);
+    }
   };
 
   return (
     <Wrapper>
       <ModalCommon
         onClose={onClose}
+        close='취소'
         confirm='선택'
         height={PROBLEMS_MODAL_HEIGHT}
         onConfirm={handleConfirm}
+        disabled={selectedIndex === -1}
       >
         <Row>
           <InputCommon bind={[query, setQuery]} />
           <ButtonCommon onClick={handleSearchClick}> 검색</ButtonCommon>
         </Row>
-        <Col>
-          {(data ?? []).map(({ id, title }, index) => (
-            <Problem key={id}>
-              <Row justifyContent='space-between' alignItems='center'>
+        <Problems>
+          {!isLoading &&
+            (problems ?? [])!.map(({ id, title }, index) => (
+              <Col key={id}>
                 <ButtonCommon
-                  width={PROBLEM_BUTTON_WIDTH}
-                  onClick={() => {
-                    handleProblemClick(index);
-                  }}
-                  clicked={index === clickedIndex}
+                  onClick={() => handleProblemClick(index)}
+                  clicked={index === selectedIndex}
                 >
                   <Title>{id}</Title>:<Title>{title}</Title>
                 </ButtonCommon>
-              </Row>
-            </Problem>
-          ))}
-        </Col>
+              </Col>
+            ))}
+        </Problems>
       </ModalCommon>
     </Wrapper>
   );

--- a/frontend/src/components/modals/ProblemsModal/style.ts
+++ b/frontend/src/components/modals/ProblemsModal/style.ts
@@ -1,17 +1,13 @@
 import styled from '@emotion/styled';
-import { Col } from 'src/components/Grid';
 
 const Wrapper = styled.div`
   position: absolute;
   z-index: 3;
-  ${Col} {
-    height: 400px;
-    overflow: scroll;
-    margin: 24px 0;
-  }
 `;
 
-const Problem = styled.div`
+const Problems = styled.div`
+  height: 200px;
+  overflow-y: scroll;
   padding: 16px;
 `;
 
@@ -24,4 +20,4 @@ const Title = styled.p`
   line-height: 1.8em;
 `;
 
-export { Wrapper, Problem, Title };
+export { Wrapper, Problems, Title };

--- a/frontend/src/components/modals/RegisterModal/index.tsx
+++ b/frontend/src/components/modals/RegisterModal/index.tsx
@@ -19,12 +19,12 @@ function RegisterModal() {
   const mutation = useMutation(putUserSettings, {
     onSuccess: () => setUser({ ...user, isRegistered: true, username }),
   });
-  const handleOnConfirm = useCallback(() => mutation.mutate(), [mutation]);
+  const handleConfirm = useCallback(() => mutation.mutate(), [mutation]);
   if (!isAuthenticated || isRegistered) {
     return null;
   }
   return (
-    <ModalCommon onConfirm={handleOnConfirm} close='로그아웃' confirm='확인'>
+    <ModalCommon onConfirm={handleConfirm} close='로그아웃' confirm='확인'>
       <Col alignItems='center'>
         <p>회원가입에 필요한 절차에요</p>
         <p>username을 알려주세요~</p>

--- a/frontend/src/components/modals/ReposModal/index.tsx
+++ b/frontend/src/components/modals/ReposModal/index.tsx
@@ -1,48 +1,70 @@
-import React from 'react';
-// import { useRecoilValue } from 'recoil';
-// import { useQuery } from 'react-query';
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useQuery } from 'react-query';
 import PropTypes from 'prop-types';
 
+import ButtonCommon from 'src/components/buttons/Common';
 import ModalCommon from 'src/components/modals/Common';
 import { Col } from 'src/components/Grid';
 
-// import userAtom from 'src/recoil/user';
+import userAtom from 'src/recoil/user';
 
-// import { Fetcher } from 'src/utils';
+import { Fetcher } from 'src/utils';
 
 import { REPOS_MODAL_HEIGHT } from 'src/globals/constants';
 
-import { Wrapper } from './style';
+import { RepoType } from 'src/types';
+
+import { Wrapper, Repos } from './style';
 
 interface Props {
-  onSelect: () => void;
+  // eslint-disable-next-line no-unused-vars
+  onSelect: (repo: RepoType) => void;
   onClose: () => void;
 }
 
 function ReposModal({ onClose, onSelect }: Props) {
-  // const user = useRecoilValue(userAtom);
-  // eslint-disable-next-line no-unused-vars
-  // const { data: repositories } = useQuery(['repositories', user._id], () =>
-  //   Fetcher.getUserRepos(user),
-  // );
-  const handleOnConfirm = () => {
-    onSelect();
+  const user = useRecoilValue(userAtom);
+
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const { data: repos, isLoading } = useQuery(['repositories', user._id], () =>
+    Fetcher.getUserRepos(user),
+  );
+  const handleConfirm = () => {
+    onSelect(repos![selectedIndex]);
+  };
+
+  const handleRepoClick = (index: number) => {
+    if (index === selectedIndex) {
+      setSelectedIndex(-1);
+    } else {
+      setSelectedIndex(index);
+    }
   };
 
   return (
     <Wrapper>
       <ModalCommon
-        onConfirm={handleOnConfirm}
+        onConfirm={handleConfirm}
         close='취소'
-        confirm='확인'
+        confirm='선택'
         height={REPOS_MODAL_HEIGHT}
         onClose={onClose}
+        disabled={selectedIndex === -1}
       >
-        <Col alignItems='center'>
-          {/* {repositories.map((repository) => ( */}
-          {/*  <>repository</> */}
-          {/* ))} */}
-        </Col>
+        <Repos>
+          {!isLoading &&
+            repos!.map((repo, index) => (
+              <Col key={repo.name}>
+                <ButtonCommon
+                  onClick={() => handleRepoClick(index)}
+                  clicked={index === selectedIndex}
+                >
+                  {repo.name}
+                </ButtonCommon>
+              </Col>
+            ))}
+        </Repos>
       </ModalCommon>
     </Wrapper>
   );

--- a/frontend/src/components/modals/ReposModal/style.ts
+++ b/frontend/src/components/modals/ReposModal/style.ts
@@ -5,5 +5,9 @@ const Wrapper = styled.div`
   z-index: 3;
 `;
 
-// eslint-disable-next-line import/prefer-default-export
-export { Wrapper };
+const Repos = styled.div`
+  overflow-y: scroll;
+  height: 400px;
+`;
+
+export { Wrapper, Repos };

--- a/frontend/src/types/repo.ts
+++ b/frontend/src/types/repo.ts
@@ -1,1 +1,4 @@
-export default interface RepoType {}
+export default interface RepoType {
+  name?: string;
+  url?: string;
+}

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -116,6 +116,16 @@ class Fetcher {
     return result.data.data;
   }
 
+  static async getUserRepo(user: UserType, repoName: string): Promise<RepoType> {
+    const result = await axios.get(
+      `${baseURL}/${version}/users/${user._id}/repositories/${repoName}`,
+      {
+        headers: { Authorization: `Bearer ${user.token}` },
+      },
+    );
+    return result.data.data;
+  }
+
   static async getUserFollows(targetUserID: string) {
     const result = await axios.get(`${baseURL}/${version}/users/${targetUserID}/follows`);
     return result.data.data;


### PR DESCRIPTION
모달 및 버튼에 disable 프롭스를 추가했습니다.
모달 diable의 작동 방식은 confirm 버튼을 못 누르는 것입니다.

### 파일 변경
- frontend/src/components/buttons/Common/index.tsx: 버튼커먼에 disable props 추가
- frontend/src/components/buttons/Common/style.ts: 버튼커먼에 disable props 추가
- frontend/src/components/cards/ExternalAuthCard/index.tsx: 깃허브 연동 추가
- frontend/src/components/inputs/ImageInput/index.tsx: 적절하지 않은 변수명 변경
- frontend/src/components/modals/Common/index.tsx: 모달 커먼에 disable 추가
- frontend/src/components/modals/PostWriteModal/index.tsx: 포스트 작성 모달에 문제, 레포 선택 핸들 함수 추가  (콘솔로그는 개발 중이라 제거하지 않았습니다. 다음 피알에서 제거하겠습니다.)
- frontend/src/components/modals/ProblemsModal/index.tsx: 문제 리스트 모달 개발
- frontend/src/components/modals/ProblemsModal/style.ts: 문제 리스트 모달 스타일 개발
- frontend/src/components/modals/RegisterModal/index.tsx: 부적절한 변수명 변경
- frontend/src/components/modals/ReposModal/index.tsx: 레포 리스트 모달 개발
- frontend/src/components/modals/ReposModal/style.ts: 레포 리스트 모달 스타일 개발
- frontend/src/utils/Fetcher.ts: 레포 하나 불러오는 fetch 함수 추가
