### PR TITLE
외부 연동 작성 잡기2

### DIFF
--- a/frontend/src/components/Post/index.tsx
+++ b/frontend/src/components/Post/index.tsx
@@ -41,7 +41,7 @@ function Post({ post, onPostDelete }: Props) {
       [...prevState].filter((comment) => comment._id !== commentID),
     );
   };
-  const { _id, user, images, content, likes, createdAt, type, external } = post;
+  const { _id, user, images, content, likes, createdAt, external } = post;
   const isMe = me._id !== user!._id;
 
   return (
@@ -59,7 +59,7 @@ function Post({ post, onPostDelete }: Props) {
         <EchoButton postID={_id!} />
       </Row>
       {likeCount !== 0 && <LikesButton postID={_id!} likeCount={likeCount} />}
-      {type === 'external' && <ExternalContent external={external!} />}
+      {external !== undefined && <ExternalContent external={external} />}
       <NormalContent content={content!} />
       <PostComments postID={_id!} comments={comments} onCommentDelete={handleCommentDelete} />
       <CommentInput postID={_id!} onCommentWrite={handleCommentWrite} />

--- a/frontend/src/components/buttons/FloatingButton/index.tsx
+++ b/frontend/src/components/buttons/FloatingButton/index.tsx
@@ -23,9 +23,14 @@ function FloatingButton({ onPostWrite }: Props) {
     setIsModalShow(false);
   }, []);
 
+  const handlePostWrite = () => {
+    setIsModalShow(false);
+    onPostWrite!();
+  };
+
   return (
     <Wrapper>
-      {isModalShow && <PostWriteModal onClose={handleClose} onPostWrite={onPostWrite} />}
+      {isModalShow && <PostWriteModal onClose={handleClose} onPostWrite={handlePostWrite} />}
       <ButtonCommon
         onClick={changeModalShow}
         width={FLOATING_BUTTON_WIDTH}

--- a/frontend/src/components/contents/ExternalContent/index.tsx
+++ b/frontend/src/components/contents/ExternalContent/index.tsx
@@ -17,19 +17,13 @@ function ExternalContent({ external }: Props) {
   const handleMoreClick = () => {
     setIsExpand(true);
   };
-  const handleLinkClick = () => {};
 
   return (
     <Wrapper expanded={isExpand}>
       <Cover hidden={isExpand} />
       {!isExpand && <MoreButton onClick={handleMoreClick}>더보기</MoreButton>}
       {!isExpand && (
-        <LinkButton
-          onClick={handleLinkClick}
-          href={external.link}
-          target='_blank'
-          rel='noreferrer noopener'
-        >
+        <LinkButton href={external.link} target='_blank' rel='noreferrer noopener'>
           바로가기
         </LinkButton>
       )}

--- a/frontend/src/components/contents/RepoContent/index.tsx
+++ b/frontend/src/components/contents/RepoContent/index.tsx
@@ -18,7 +18,7 @@ function RepoContent({ content, link, info }: Props) {
       <Row justifyContent='space-between'>
         <p>별 {info.starCount}</p>
         <p>포크 {info.forkCount}</p>
-        {Object.keys(info.language).map((language) => (
+        {Object.keys(info.language ?? {}).map((language) => (
           <Col key={language}>
             <p>{language}</p>
             <p>{info.language[language]}%</p>

--- a/frontend/src/components/modals/PostWriteModal/style.ts
+++ b/frontend/src/components/modals/PostWriteModal/style.ts
@@ -24,4 +24,38 @@ const IconHolder = styled.div`
   height: 48px;
 `;
 
-export { Textarea, IconHolder };
+const Preview = styled.div`
+  position: relative;
+  height: 100px;
+  overflow-y: hidden;
+  border-radius: 16px;
+  padding: 16px;
+`;
+const Cover = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  background: linear-gradient(rgba(0, 0, 0, 0), rgba(18, 18, 18, 1));
+`;
+
+const LinkButton = styled.a`
+  position: absolute;
+  bottom: 20px;
+  right: 0;
+  left: 0;
+  width: 80px;
+  height: 40px;
+  margin: auto;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    border: 1px solid;
+  }
+`;
+
+export { Textarea, IconHolder, Preview, Cover, LinkButton };

--- a/frontend/src/components/modals/ProblemsModal/index.tsx
+++ b/frontend/src/components/modals/ProblemsModal/index.tsx
@@ -24,7 +24,7 @@ interface Props {
 function ProblemsModal({ onClose, onSelect }: Props) {
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [query, setQuery] = useState('');
-  const { mutate, data: problems, isLoading } = useMutation(() => Fetcher.getProblemSearch(query));
+  const { mutate, data: problems } = useMutation(() => Fetcher.getProblems(query));
   const handleSearchClick = () => {
     mutate();
   };
@@ -56,17 +56,16 @@ function ProblemsModal({ onClose, onSelect }: Props) {
           <ButtonCommon onClick={handleSearchClick}> 검색</ButtonCommon>
         </Row>
         <Problems>
-          {!isLoading &&
-            (problems ?? [])!.map(({ id, title }, index) => (
-              <Col key={id}>
-                <ButtonCommon
-                  onClick={() => handleProblemClick(index)}
-                  clicked={index === selectedIndex}
-                >
-                  <Title>{id}</Title>:<Title>{title}</Title>
-                </ButtonCommon>
-              </Col>
-            ))}
+          {(problems ?? [])!.map(({ id, title }, index) => (
+            <Col key={id}>
+              <ButtonCommon
+                onClick={() => handleProblemClick(index)}
+                clicked={index === selectedIndex}
+              >
+                <Title>{id}</Title>:<Title>{title}</Title>
+              </ButtonCommon>
+            </Col>
+          ))}
         </Problems>
       </ModalCommon>
     </Wrapper>

--- a/frontend/src/components/modals/ReposModal/index.tsx
+++ b/frontend/src/components/modals/ReposModal/index.tsx
@@ -27,9 +27,7 @@ function ReposModal({ onClose, onSelect }: Props) {
   const user = useRecoilValue(userAtom);
 
   const [selectedIndex, setSelectedIndex] = useState(-1);
-  const { data: repos, isLoading } = useQuery(['repositories', user._id], () =>
-    Fetcher.getUserRepos(user),
-  );
+  const { data: repos } = useQuery(['repositories', user._id], () => Fetcher.getUserRepos(user));
   const handleConfirm = () => {
     onSelect(repos![selectedIndex]);
   };
@@ -53,17 +51,16 @@ function ReposModal({ onClose, onSelect }: Props) {
         disabled={selectedIndex === -1}
       >
         <Repos>
-          {!isLoading &&
-            repos!.map((repo, index) => (
-              <Col key={repo.name}>
-                <ButtonCommon
-                  onClick={() => handleRepoClick(index)}
-                  clicked={index === selectedIndex}
-                >
-                  {repo.name}
-                </ButtonCommon>
-              </Col>
-            ))}
+          {(repos ?? []).map((repo, index) => (
+            <Col key={repo.name}>
+              <ButtonCommon
+                onClick={() => handleRepoClick(index)}
+                clicked={index === selectedIndex}
+              >
+                {repo.name}
+              </ButtonCommon>
+            </Col>
+          ))}
         </Repos>
       </ModalCommon>
     </Wrapper>

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -6,7 +6,6 @@ import ExternalType from './external';
 
 export default interface PostType {
   _id?: string;
-  type?: string;
   content?: string;
   images?: ImageType[];
   user?: UserType;

--- a/frontend/src/types/repo.ts
+++ b/frontend/src/types/repo.ts
@@ -1,4 +1,4 @@
 export default interface RepoType {
-  name?: string;
-  url?: string;
+  name: string;
+  url: string;
 }

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -10,6 +10,7 @@ import {
   RepoType,
   ProblemType,
   DashboardUserInfoType,
+  ExternalType,
 } from 'src/types';
 
 const baseURL = process.env.NEXT_PUBLIC_SERVER_URL;
@@ -117,7 +118,7 @@ class Fetcher {
     return result.data.data;
   }
 
-  static async getUserRepo(user: UserType, repoName: string): Promise<RepoType> {
+  static async getUserRepo(user: UserType, repoName: string): Promise<ExternalType> {
     const result = await axios.get(
       `${baseURL}/${version}/users/${user._id}/repositories/${repoName}`,
       {
@@ -137,10 +138,15 @@ class Fetcher {
     return result.data.data;
   }
 
-  static async getProblemSearch(query: string): Promise<ProblemType[]> {
+  static async getProblems(query: string): Promise<ProblemType[]> {
     const result = await axios.get(`${baseURL}/${version}/problems`, {
       params: { query },
     });
+    return result.data.data;
+  }
+
+  static async getProblem(id: string): Promise<ExternalType> {
+    const result = await axios.get(`${baseURL}/${version}/problems/${id}`);
     return result.data.data;
   }
 
@@ -153,10 +159,11 @@ class Fetcher {
     user: UserType,
     content: string,
     images: string[],
+    external?: ExternalType,
   ): Promise<ReturnType<PostType>> {
     const result = await axios.post(
       `${baseURL}/${version}/posts`,
-      { userID: user._id, content, images },
+      { userID: user._id, content, images, external },
       { headers: { Authorization: `Bearer ${user.token}` } },
     );
     return result.data;


### PR DESCRIPTION
블로그 작성하기만 제외하고 나머지 다 한 피알입니다~

### 파일 변경
- frontend/src/components/Post/index.tsx: 포스트타입에서 type 제거
- frontend/src/components/buttons/FloatingButton/index.tsx: 포스트 작성 시 부모 컴포넌트에서 모달 내리도록 변경
- frontend/src/components/contents/ExternalContent/index.tsx: 사용하지 않는 함수 삭제
- frontend/src/components/contents/RepoContent/index.tsx: 언어 사용 데이터가 들어오지 않을 시를 대비함
- frontend/src/components/modals/PostWriteModal/index.tsx: 뮤테이션 추가
- frontend/src/components/modals/PostWriteModal/style.ts: 외부 자료 미리보는 레이아웃 작성
- frontend/src/components/modals/ProblemsModal/index.tsx: 문제 리스트 모달 예외 사항 좀 더 치밀하게 대비
- frontend/src/components/modals/ReposModal/index.tsx: 레포 리스트 모달 예외 사항 좀 더 치밀하게 대비
- frontend/src/types/post.ts: 포스트타입에서 type제거
- frontend/src/utils/Fetcher.ts: 문제 세부사항 가져오기, 레포 세부사항 가져오기 함수 추가
