### PR TITLE
대시보드 히스토리 추가 삭제 구현

### DIFF
--- a/frontend/src/components/buttons/dashboardSettings/DashboardHistoryDeleteButton/index.tsx
+++ b/frontend/src/components/buttons/dashboardSettings/DashboardHistoryDeleteButton/index.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { IoCloseCircleOutline } from 'react-icons/io5';
+
+import DashboardSettingCommon from 'src/components/buttons/dashboardSettings/Common';
+import DashboardHistoryDeleteModal from 'src/components/modals/DashboardHistoryDeleteModal';
+
+interface Props {
+  historyID: string;
+}
+
+function DashboardHistoryDeleteButton({ historyID }: Props) {
+  const [isModalShow, setIsModalShow] = useState(false);
+
+  const switchIsModalShow = () => {
+    setIsModalShow((prevState) => !prevState);
+  };
+
+  return (
+    <DashboardSettingCommon
+      icon={<IoCloseCircleOutline />}
+      isModalShow={isModalShow}
+      modal={<DashboardHistoryDeleteModal historyID={historyID} onClose={switchIsModalShow} />}
+      onClick={switchIsModalShow}
+    />
+  );
+}
+
+DashboardHistoryDeleteButton.propTypes = {
+  historyID: PropTypes.string.isRequired,
+};
+
+export default DashboardHistoryDeleteButton;

--- a/frontend/src/components/cards/DashboardHistoryCard/index.tsx
+++ b/frontend/src/components/cards/DashboardHistoryCard/index.tsx
@@ -1,39 +1,45 @@
 import { useRecoilValue } from 'recoil';
-import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 
 import CardCommon from 'src/components/cards/Common';
 import DashboardHistoryAddButton from 'src/components/buttons/dashboardSettings/DashboardHistoryAddButton';
+import DashboardHistoryDeleteButton from 'src/components/buttons/dashboardSettings/DashboardHistoryDeleteButton';
+import { Col } from 'src/components/Grid';
 
 import { DASHBOARD_RIGHT_SECTION_CARD_WIDTH } from 'src/globals/constants';
 
 import userAtom from 'src/recoil/user';
+import { dashboardHistoriesSelector } from 'src/recoil/dashboardUserInfo';
 
-import { History, HorizentalLine } from './style';
+import { History, HorizentalLine, Section } from './style';
 
-interface Props {
-  username: string;
-}
-
-function DashboardHistoryCard({ username }: Props) {
+function DashboardHistoryCard() {
+  const router = useRouter();
+  const username = router.query.username as string;
   const user = useRecoilValue(userAtom);
+  const dashboardHistories = useRecoilValue(dashboardHistoriesSelector);
   const isMe = user.username === username;
+
   return (
     <CardCommon width={DASHBOARD_RIGHT_SECTION_CARD_WIDTH}>
       <History>
-        <p>XXXX.XX.XX</p>
-        <HorizentalLine />
-        <p>example history</p>
-        <p>XXXX.XX.XX</p>
-        <HorizentalLine />
-        <p>example history</p>
+        {dashboardHistories.map((history) => {
+          const date = new Date(history.date!);
+          return (
+            <Section key={history._id}>
+              <Col>
+                <p>{`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`}</p>
+                <HorizentalLine />
+                <p>{history.content}</p>
+              </Col>
+              {isMe && <DashboardHistoryDeleteButton historyID={history._id} />}
+            </Section>
+          );
+        })}
       </History>
       {isMe && <DashboardHistoryAddButton />}
     </CardCommon>
   );
 }
-
-DashboardHistoryCard.propTypes = {
-  username: PropTypes.string.isRequired,
-};
 
 export default DashboardHistoryCard;

--- a/frontend/src/components/cards/DashboardHistoryCard/index.tsx
+++ b/frontend/src/components/cards/DashboardHistoryCard/index.tsx
@@ -11,6 +11,8 @@ import { DASHBOARD_RIGHT_SECTION_CARD_WIDTH } from 'src/globals/constants';
 import userAtom from 'src/recoil/user';
 import { dashboardHistoriesSelector } from 'src/recoil/dashboardUserInfo';
 
+import { getBirthdayFormat } from 'src/utils/moment';
+
 import { History, HorizentalLine, Section } from './style';
 
 function DashboardHistoryCard() {
@@ -23,19 +25,16 @@ function DashboardHistoryCard() {
   return (
     <CardCommon width={DASHBOARD_RIGHT_SECTION_CARD_WIDTH}>
       <History>
-        {dashboardHistories.map((history) => {
-          const date = new Date(history.date!);
-          return (
-            <Section key={history._id}>
-              <Col>
-                <p>{`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`}</p>
-                <HorizentalLine />
-                <p>{history.content}</p>
-              </Col>
-              {isMe && <DashboardHistoryDeleteButton historyID={history._id} />}
-            </Section>
-          );
-        })}
+        {dashboardHistories.map((history) => (
+          <Section key={history._id}>
+            <Col>
+              <p>{getBirthdayFormat(history.date!)}</p>
+              <HorizentalLine />
+              <p>{history.content}</p>
+            </Col>
+            {isMe && <DashboardHistoryDeleteButton historyID={history._id} />}
+          </Section>
+        ))}
       </History>
       {isMe && <DashboardHistoryAddButton />}
     </CardCommon>

--- a/frontend/src/components/cards/DashboardHistoryCard/style.ts
+++ b/frontend/src/components/cards/DashboardHistoryCard/style.ts
@@ -5,15 +5,20 @@ import { DASHBOARD_HISTORY_MARGIN_LEFT } from 'src/globals/constants';
 const History = styled.div`
   margin-left: ${DASHBOARD_HISTORY_MARGIN_LEFT}px;
   border-left: 2px solid #ffffff;
+`;
+
+const HorizentalLine = styled.div`
+  width: 200px;
+  border-bottom: 1px solid #ffffff;
+`;
+
+const Section = styled.div`
+  width: 100%;
+  display: flex;
   p {
-    padding: 16px 8px;
+    padding: 8px;
     word-wrap: break-word;
   }
 `;
 
-const HorizentalLine = styled.div`
-  width: 70%;
-  border-bottom: 1px solid #ffffff;
-`;
-
-export { History, HorizentalLine };
+export { History, HorizentalLine, Section };

--- a/frontend/src/components/modals/Common/index.tsx
+++ b/frontend/src/components/modals/Common/index.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Row, Col, Spacer } from 'src/components/Grid';
 import ButtonCommon from 'src/components/buttons/Common';
 
-import { DEAULT_MODAL_WIDTH } from 'src/globals/constants';
+import { DEFAULT_MODAL_WIDTH } from 'src/globals/constants';
 
 import { Background, Card } from './style';
 
@@ -66,7 +66,7 @@ ModalCommon.defaultProps = {
   onConfirm: () => {},
   close: '',
   confirm: '',
-  width: DEAULT_MODAL_WIDTH,
+  width: DEFAULT_MODAL_WIDTH,
   height: 0,
   disabled: false,
 };

--- a/frontend/src/components/modals/DashboardHistoryAddModal/index.tsx
+++ b/frontend/src/components/modals/DashboardHistoryAddModal/index.tsx
@@ -1,16 +1,60 @@
+import { useState } from 'react';
+import { useMutation } from 'react-query';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import PropTypes from 'prop-types';
+
 import ModalCommon from 'src/components/modals/Common';
+import InputCommon from 'src/components/inputs/Common';
+import { Col, Row } from 'src/components/Grid';
+
+import { HISTORY_INPUT_WIDTH } from 'src/globals/constants';
+
+import userAtom from 'src/recoil/user';
+import { dashboardHistoriesSelector } from 'src/recoil/dashboardUserInfo';
+
+import { Fetcher } from 'src/utils';
+
+import { Label } from './style';
 
 interface Props {
   onClose: () => void;
 }
 
 function DashboardHistoryAddModal({ onClose }: Props) {
-  const onHistoryWrite = () => {};
+  const user = useRecoilValue(userAtom);
+  const [dashboardHistories, setDashboardHistories] = useRecoilState(dashboardHistoriesSelector);
+  const [content, setContent] = useState('');
+  const [date, setDate] = useState('');
+
+  const { mutate } = useMutation(() => Fetcher.postDashboardHistory(user, content, date), {
+    onSuccess: (data) => {
+      setDashboardHistories([...dashboardHistories, data]);
+      onClose();
+    },
+  });
+
+  const handleConfirm = () => {
+    mutate();
+  };
+
   return (
-    <ModalCommon onConfirm={onHistoryWrite} onClose={onClose} confirm='저장' close='취소'>
-      히스토리 추가
+    <ModalCommon onConfirm={handleConfirm} onClose={onClose} confirm='저장' close='취소'>
+      <Col>
+        <Row>
+          <Label>date</Label>
+          <InputCommon bind={[date, setDate]} width={HISTORY_INPUT_WIDTH} />
+        </Row>
+        <Row>
+          <Label>content</Label>
+          <InputCommon bind={[content, setContent]} width={HISTORY_INPUT_WIDTH} />
+        </Row>
+      </Col>
     </ModalCommon>
   );
 }
+
+DashboardHistoryAddModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
 
 export default DashboardHistoryAddModal;

--- a/frontend/src/components/modals/DashboardHistoryAddModal/style.ts
+++ b/frontend/src/components/modals/DashboardHistoryAddModal/style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+const Label = styled.div`
+  text-align: right;
+  width: 100px;
+  font-size: 24px;
+  padding: 0 24px;
+  margin: 8px;
+`;
+
+// eslint-disable-next-line import/prefer-default-export
+export { Label };

--- a/frontend/src/components/modals/DashboardHistoryDeleteModal/index.tsx
+++ b/frontend/src/components/modals/DashboardHistoryDeleteModal/index.tsx
@@ -1,0 +1,44 @@
+import { useMutation } from 'react-query';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import PropTypes from 'prop-types';
+
+import ModalCommon from 'src/components/modals/Common';
+
+import userAtom from 'src/recoil/user';
+import { dashboardHistoriesSelector } from 'src/recoil/dashboardUserInfo';
+
+import { Fetcher } from 'src/utils';
+
+interface Props {
+  onClose: () => void;
+  historyID: string;
+}
+
+function DashboardHistoryDeleteModal({ onClose, historyID }: Props) {
+  const user = useRecoilValue(userAtom);
+  const [dashboardHistories, setDashboardHistories] = useRecoilState(dashboardHistoriesSelector);
+
+  const { mutate } = useMutation(() => Fetcher.deleteDashboardHistory(user, historyID), {
+    onSuccess: () => {
+      setDashboardHistories([...dashboardHistories].filter((history) => history._id !== historyID));
+      onClose();
+    },
+  });
+
+  const handleConfirm = () => {
+    mutate();
+  };
+
+  return (
+    <ModalCommon onConfirm={handleConfirm} onClose={onClose} confirm='삭제' close='취소'>
+      히스토리를 삭제하시겠습니까?
+    </ModalCommon>
+  );
+}
+
+DashboardHistoryDeleteModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  historyID: PropTypes.string.isRequired,
+};
+
+export default DashboardHistoryDeleteModal;

--- a/frontend/src/globals/constants.ts
+++ b/frontend/src/globals/constants.ts
@@ -104,7 +104,7 @@ export const DELETE_MODAL_TITLE_HEIGHT = 50;
 
 export const EXTERNAL_MODAL_HEIGHT = 400;
 
-export const DEAULT_MODAL_WIDTH = 384;
+export const DEFAULT_MODAL_WIDTH = 384;
 
 // COUNT
 export const SUGGESTION_COUNT = 3;

--- a/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
+++ b/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
@@ -2,9 +2,10 @@ import { selector } from 'recoil';
 
 import { HistoryType } from 'src/types';
 
-import { compareTime } from 'src/utils/moment';
-
 import dashboardUserInfoAtom from './atom';
+
+const compareTime = (firstHistory: HistoryType, secondHistory: HistoryType) =>
+  new Date(firstHistory.date).getTime() - new Date(secondHistory.date).getTime();
 
 const dashboardHistoriesSelector = selector<HistoryType[]>({
   key: 'historiesSelector',

--- a/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
+++ b/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
@@ -2,11 +2,22 @@ import { selector } from 'recoil';
 
 import { HistoryType } from 'src/types';
 
+import { timeCompare } from 'src/utils/moment';
+
 import dashboardUserInfoAtom from './atom';
 
 const dashboardHistoriesSelector = selector<HistoryType[]>({
   key: 'historiesSelector',
   get: ({ get }) => get(dashboardUserInfoAtom).dashboardHistories ?? [],
+  set: ({ set }, newValue) => {
+    set(dashboardUserInfoAtom, (oldValue) => {
+      const newdashboardUserInfo = { ...oldValue };
+      if (Array.isArray(newValue)) {
+        newdashboardUserInfo.dashboardHistories = [...newValue].sort(timeCompare);
+      }
+      return newdashboardUserInfo;
+    });
+  },
 });
 
 export default dashboardHistoriesSelector;

--- a/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
+++ b/frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts
@@ -2,7 +2,7 @@ import { selector } from 'recoil';
 
 import { HistoryType } from 'src/types';
 
-import { timeCompare } from 'src/utils/moment';
+import { compareTime } from 'src/utils/moment';
 
 import dashboardUserInfoAtom from './atom';
 
@@ -13,7 +13,7 @@ const dashboardHistoriesSelector = selector<HistoryType[]>({
     set(dashboardUserInfoAtom, (oldValue) => {
       const newdashboardUserInfo = { ...oldValue };
       if (Array.isArray(newValue)) {
-        newdashboardUserInfo.dashboardHistories = [...newValue].sort(timeCompare);
+        newdashboardUserInfo.dashboardHistories = [...newValue].sort(compareTime);
       }
       return newdashboardUserInfo;
     });

--- a/frontend/src/types/history.ts
+++ b/frontend/src/types/history.ts
@@ -1,0 +1,6 @@
+export default interface HistoryType {
+  userID: string;
+  content: string;
+  date: string;
+  _id: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ import ExternalType from './external';
 import { RepoInfoType, ProblemInfoType } from './info';
 import StackType from './stack';
 import DashboardUserInfoType from './dashboardUserInfo';
+import HistoryType from './history';
 
 export type {
   UserType,
@@ -29,4 +30,5 @@ export type {
   ProblemInfoType,
   StackType,
   DashboardUserInfoType,
+  HistoryType,
 };

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -185,6 +185,10 @@ class Fetcher {
     return result.data.data;
   }
 
+  static async getLogout() {
+    window.open(`${baseURL}/${version}/users/logout`, '_self');
+  }
+
   static async postPost(
     user: UserType,
     content: string,

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -234,6 +234,19 @@ class Fetcher {
     return result.data;
   }
 
+  static async postDashboardHistory(
+    user: UserType,
+    content: string,
+    date: string,
+  ): Promise<HistoryType> {
+    const result = await axios.post(
+      `${baseURL}/${version}/users/${user._id}/dashboard/histories`,
+      { content, date },
+      { headers: { Authorization: `Bearer ${user.token}` } },
+    );
+    return result.data;
+  }
+
   static async putUserFollow(user: UserType, targetUserID: string): Promise<void> {
     await axios.post(
       `${baseURL}/${version}/users/${targetUserID}/follows`,
@@ -317,6 +330,13 @@ class Fetcher {
   static async deleteComment(user: UserType, postID: string, commentID: string): Promise<void> {
     await axios.delete(`${baseURL}/${version}/posts/${postID}/comments/${commentID}`, {
       data: { userID: `${user._id}` },
+      headers: { Authorization: `Bearer ${user.token}` },
+    });
+  }
+
+  static async deleteDashboardHistory(user: UserType, historyID: string): Promise<void> {
+    await axios.delete(`${baseURL}/${version}/users/${user._id}/dashboard/histories`, {
+      data: { historyID },
       headers: { Authorization: `Bearer ${user.token}` },
     });
   }

--- a/frontend/src/utils/moment.ts
+++ b/frontend/src/utils/moment.ts
@@ -40,7 +40,7 @@ const getBirthdayFormat = (time?: string) => {
   return '';
 };
 
-const timeCompare = (a: HistoryType, b: HistoryType) =>
-  new Date(a.date).getTime() - new Date(b.date).getTime();
+const timeCompare = (firstHistory: HistoryType, secondHistory: HistoryType) =>
+  new Date(firstHistory.date).getTime() - new Date(secondHistory.date).getTime();
 
 export { getFromNow, getBirthdayFormat, timeCompare };

--- a/frontend/src/utils/moment.ts
+++ b/frontend/src/utils/moment.ts
@@ -40,7 +40,7 @@ const getBirthdayFormat = (time?: string) => {
   return '';
 };
 
-const timeCompare = (firstHistory: HistoryType, secondHistory: HistoryType) =>
+const compareTime = (firstHistory: HistoryType, secondHistory: HistoryType) =>
   new Date(firstHistory.date).getTime() - new Date(secondHistory.date).getTime();
 
-export { getFromNow, getBirthdayFormat, timeCompare };
+export { getFromNow, getBirthdayFormat, compareTime };

--- a/frontend/src/utils/moment.ts
+++ b/frontend/src/utils/moment.ts
@@ -1,3 +1,5 @@
+import { HistoryType } from 'src/types';
+
 const MINUTE = 60; // SECONDS
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
@@ -30,5 +32,15 @@ const getFromNow = (time: string) => {
   return '방금';
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export { getFromNow };
+const getBirthdayFormat = (time?: string) => {
+  if (time) {
+    const date = new Date(time);
+    return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  }
+  return '';
+};
+
+const timeCompare = (a: HistoryType, b: HistoryType) =>
+  new Date(a.date).getTime() - new Date(b.date).getTime();
+
+export { getFromNow, getBirthdayFormat, timeCompare };

--- a/frontend/src/utils/moment.ts
+++ b/frontend/src/utils/moment.ts
@@ -1,5 +1,3 @@
-import { HistoryType } from 'src/types';
-
 const MINUTE = 60; // SECONDS
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
@@ -40,7 +38,4 @@ const getBirthdayFormat = (time?: string) => {
   return '';
 };
 
-const compareTime = (firstHistory: HistoryType, secondHistory: HistoryType) =>
-  new Date(firstHistory.date).getTime() - new Date(secondHistory.date).getTime();
-
-export { getFromNow, getBirthdayFormat, compareTime };
+export { getFromNow, getBirthdayFormat };


### PR DESCRIPTION
### 제목
대시보드 히스토리 추가 삭제 구현

### 파일 변경
- frontend/src/components/buttons/dashboardSettings/DashboardHistoryDeleteButton/index.tsx : 대시보드 히스토리 삭제 버튼 구현
- frontend/src/components/cards/DashboardHistoryCard/index.tsx : 대시보드 히스토리 카드 구현
- frontend/src/components/cards/DashboardHistoryCard/style.ts : 스타일 적용
- frontend/src/components/modals/Common/index.tsx : 상수 오타 수정
- frontend/src/components/modals/DashboardHistoryAddModal/index.tsx : 대시보드 히스토리 추가 모달 구현
- frontend/src/components/modals/DashboardHistoryAddModal/style.ts : 스타일 적용
- frontend/src/components/modals/DashboardHistoryDeleteModal/index.tsx : 대시보드 히스토리 삭제 모달 구현
- frontend/src/globals/constants.ts : 상수 오타 수정
- frontend/src/pages/_app.tsx : dashboarduserinfo props 추가
- frontend/src/recoil/dashboardUserInfo/dashboardHistories.ts : 시간 순으로 정렬 추가
- frontend/src/types/history.ts : 히스토리 타입 추가
- frontend/src/types/index.ts : 히스토리 타입 추가
- frontend/src/utils/Fetcher.ts
- frontend/src/utils/moment.ts