### PR TITLE
RecoilRoot 중첩할 시 상위 루트의 값이 내려가지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/users/[username]/dashboard.tsx
+++ b/frontend/src/pages/users/[username]/dashboard.tsx
@@ -1,4 +1,4 @@
-import { MutableSnapshot, RecoilRoot } from 'recoil';
+import { MutableSnapshot, RecoilRoot, useRecoilValue } from 'recoil';
 
 import Header from 'src/components/Header';
 import DashboardHead from 'src/components/heads/DashboardHead';
@@ -9,8 +9,9 @@ import DashboardTeckStacksCard from 'src/components/cards/DashboardTechStacksCar
 import { Row, Col } from 'src/components/Grid';
 
 import dashboardUserInfoAtom from 'src/recoil/dashboardUserInfo';
+import userAtom from 'src/recoil/user';
 
-import { DashboardUserInfoType } from 'src/types';
+import { DashboardUserInfoType, UserType } from 'src/types';
 
 import { Page } from 'src/styles';
 
@@ -21,18 +22,22 @@ interface Props {
 }
 
 const initState =
-  (dashboardUserInfo: DashboardUserInfoType) =>
-  ({ set }: MutableSnapshot) =>
+  (dashboardUserInfo: DashboardUserInfoType, user: UserType) =>
+  ({ set }: MutableSnapshot) => {
     set(dashboardUserInfoAtom, dashboardUserInfo);
+    set(userAtom, user);
+  };
 
 function Dashboard({ dashboardUserInfo }: Props) {
   const { profileImage, username } = dashboardUserInfo;
+  const user = useRecoilValue(userAtom);
+
   return (
     <>
       <DashboardHead username={username} profileImage={profileImage} />
       <Header />
       <Page.Main>
-        <RecoilRoot initializeState={initState(dashboardUserInfo)}>
+        <RecoilRoot initializeState={initState(dashboardUserInfo, user)}>
           <Col alignItems='center'>
             <Row>
               <DashboardBasicCard />


### PR DESCRIPTION
https://recoiljs.org/ko/docs/api-reference/core/RecoilRoot/

override 속성을 사용하여 상위 루트의 상태 값을 override 해주려 했으나,
override={false} 와 initializeState 속성을 함께 사용하지 못하는 것을 확인했습니다.

그래서 initializeState 에서 상위 상태인 user 상태를 추가로 초기화 해주었습니다.