### PR TITLE
홈 타임라인 첫 포스트 ServerSide에서 가져오기 + 스크롤 복원 문제 커스텀 훅으로 해결

### DIFF
--- a/frontend/src/components/Timeline/index.tsx
+++ b/frontend/src/components/Timeline/index.tsx
@@ -28,7 +28,7 @@ function Timeline({ pages, onPostDelete, onNeedMore, hasNextPage, isFetchingNext
 
       <div ref={ref} />
       {isFetchingNextPage && <ReactLoading type='bubbles' color='#ffffff' />}
-      {!hasNextPage && <p>더 이상 게시물이 없습니다.</p>}
+      {!hasNextPage && <p>끝</p>}
     </>
   );
 }

--- a/frontend/src/components/mains/HomeMain/index.tsx
+++ b/frontend/src/components/mains/HomeMain/index.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useInfiniteQuery } from 'react-query';
+
+import SigninCard from 'src/components/cards/SigninCard';
+import SuggestionCard from 'src/components/cards/SuggestionCard';
+import FloatingButton from 'src/components/buttons/FloatingButton';
+import Post from 'src/components/Post';
+import Timeline from 'src/components/Timeline';
+import { Col } from 'src/components/Grid';
+
+import userAtom, {
+  hasFollowSelector,
+  isAuthenticatedSelector,
+  isRegisteredSelector,
+} from 'src/recoil/user';
+
+import { Fetcher } from 'src/utils';
+
+import { PostType } from 'src/types';
+
+import { Page } from 'src/styles';
+
+interface Props {
+  firstPost?: PostType;
+}
+
+function HomeMain({ firstPost }: Props) {
+  const user = useRecoilValue(userAtom);
+  const hasFollow = useRecoilValue(hasFollowSelector);
+  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
+  const isRegistered = useRecoilValue(isRegisteredSelector);
+  const [hasFollowTemp] = useState(hasFollow);
+
+  const { refetch, data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    ['home', 'posts', user],
+    (context) => Fetcher.getPosts(user, context),
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
+  );
+
+  return (
+    <Page.Main>
+      <Col alignItems='center'>
+        {!isAuthenticated && <SigninCard />}
+        {isRegistered && !hasFollowTemp && <SuggestionCard />}
+        {isRegistered && (
+          <>
+            {firstPost && <Post onPostDelete={refetch} post={firstPost} />}
+            <Timeline
+              pages={data?.pages}
+              onPostDelete={refetch}
+              onNeedMore={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+            />
+          </>
+        )}
+      </Col>
+      {isRegistered && <FloatingButton onPostWrite={refetch} />}
+    </Page.Main>
+  );
+}
+
+HomeMain.defaultProps = {
+  firstPost: undefined,
+};
+
+export default HomeMain;

--- a/frontend/src/components/mains/RandomMain/index.tsx
+++ b/frontend/src/components/mains/RandomMain/index.tsx
@@ -1,0 +1,40 @@
+import { useRecoilValue } from 'recoil';
+import { useInfiniteQuery } from 'react-query';
+
+import { Col } from 'src/components/Grid';
+import Timeline from 'src/components/Timeline';
+import FloatingButton from 'src/components/buttons/FloatingButton';
+
+import { Page } from 'src/styles';
+
+import { isRegisteredSelector } from 'src/recoil/user';
+
+import { Fetcher } from 'src/utils';
+
+function RandomMain() {
+  const isRegistered = useRecoilValue(isRegisteredSelector);
+  const { refetch, data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    ['random', 'posts'],
+    (context) => Fetcher.getRandomPosts(context),
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
+  );
+
+  return (
+    <Page.Main>
+      <Col alignItems='center'>
+        <Timeline
+          pages={data?.pages}
+          onPostDelete={refetch}
+          onNeedMore={fetchNextPage}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      </Col>
+      {isRegistered && <FloatingButton />}
+    </Page.Main>
+  );
+}
+
+export default RandomMain;

--- a/frontend/src/components/mains/SettingsMain/index.tsx
+++ b/frontend/src/components/mains/SettingsMain/index.tsx
@@ -1,0 +1,33 @@
+import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
+
+import UserSettingsCard from 'src/components/cards/UserSettingsCard';
+import ExternalAuthCard from 'src/components/cards/ExternalAuthCard';
+import PermissionDeniedCard from 'src/components/cards/PermissionDeniedCard';
+import { Col } from 'src/components/Grid';
+
+import { Page } from 'src/styles';
+
+import userAtom from 'src/recoil/user';
+
+function SettingsMain() {
+  const user = useRecoilValue(userAtom);
+  const router = useRouter();
+  const targetUsername = router.query.username;
+  return (
+    <Page.Main>
+      <Col justifyContent='center' alignItems='center'>
+        {targetUsername === user.username ? (
+          <>
+            <UserSettingsCard />
+            <ExternalAuthCard />
+          </>
+        ) : (
+          <PermissionDeniedCard />
+        )}
+      </Col>
+    </Page.Main>
+  );
+}
+
+export default SettingsMain;

--- a/frontend/src/components/mains/UserMain/index.tsx
+++ b/frontend/src/components/mains/UserMain/index.tsx
@@ -1,0 +1,59 @@
+import { useRecoilValue } from 'recoil';
+import { useInfiniteQuery } from 'react-query';
+
+import Timeline from 'src/components/Timeline';
+import SigninCard from 'src/components/cards/SigninCard';
+import UserInfoCard from 'src/components/cards/UserInfoCard';
+import UserNotFoundCard from 'src/components/cards/UserNotFoundCard';
+import FloatingButton from 'src/components/buttons/FloatingButton';
+import { Col } from 'src/components/Grid';
+
+import { Page } from 'src/styles';
+
+import { isAuthenticatedSelector, isRegisteredSelector } from 'src/recoil/user';
+
+import { Fetcher } from 'src/utils';
+
+import { UserType } from 'src/types';
+
+interface Props {
+  targetUser: UserType;
+}
+
+function UserMain({ targetUser }: Props) {
+  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
+  const isRegistered = useRecoilValue(isRegisteredSelector);
+
+  const isUserExist = Object.keys(targetUser).length !== 0;
+  const { refetch, data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    ['user', 'posts', targetUser],
+    (context) => Fetcher.getUserPosts(targetUser, context),
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
+  );
+  return (
+    <Page.Main>
+      <Col alignItems='center'>
+        {!isAuthenticated && <SigninCard />}
+        {isUserExist ? (
+          <>
+            <UserInfoCard targetUser={targetUser} />
+            <Timeline
+              pages={data?.pages}
+              onPostDelete={refetch}
+              onNeedMore={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+            />
+          </>
+        ) : (
+          <UserNotFoundCard />
+        )}
+      </Col>
+      {isRegistered && <FloatingButton onPostWrite={refetch} />}
+    </Page.Main>
+  );
+}
+
+export default UserMain;

--- a/frontend/src/hooks/scrollResoration/index.ts
+++ b/frontend/src/hooks/scrollResoration/index.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import Router, { NextRouter } from 'next/router';
+
+function saveScrollPos(url: string) {
+  const scrollPos = { x: window.scrollX, y: window.scrollY };
+  sessionStorage.setItem(url, JSON.stringify(scrollPos));
+}
+
+function restoreScrollPos(url: string) {
+  const scrollPos = JSON.parse(<string>sessionStorage.getItem(url));
+  if (scrollPos) {
+    window.scrollTo(scrollPos.x, scrollPos.y);
+  }
+}
+
+export default function useScrollRestoration(router: NextRouter) {
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if ('scrollRestoration' in window.history) {
+      let shouldScrollRestore = false;
+      window.history.scrollRestoration = 'manual';
+      restoreScrollPos(router.asPath);
+
+      const onBeforeUnload = () => {
+        saveScrollPos(router.asPath);
+      };
+
+      const onRouteChangeStart = () => {
+        saveScrollPos(router.asPath);
+      };
+
+      const onRouteChangeComplete = (url: string) => {
+        if (shouldScrollRestore) {
+          shouldScrollRestore = false;
+          restoreScrollPos(url);
+        }
+      };
+
+      window.addEventListener('beforeunload', onBeforeUnload);
+      Router.events.on('routeChangeStart', onRouteChangeStart);
+      Router.events.on('routeChangeComplete', onRouteChangeComplete);
+      Router.beforePopState(() => {
+        shouldScrollRestore = true;
+        return true;
+      });
+
+      return () => {
+        window.removeEventListener('beforeunload', onBeforeUnload);
+        Router.events.off('routeChangeStart', onRouteChangeStart);
+        Router.events.off('routeChangeComplete', onRouteChangeComplete);
+        Router.beforePopState(() => true);
+      };
+    }
+  }, [router]);
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,7 +1,5 @@
-import PropTypes from 'prop-types';
-import type { AppContext, AppProps } from 'next/app';
+import type { AppProps } from 'next/app';
 import { ThemeProvider, Global } from '@emotion/react';
-import { MutableSnapshot, RecoilRoot } from 'recoil';
 import { QueryClientProvider, QueryClient } from 'react-query';
 
 import RegisterModal from 'src/components/modals/RegisterModal';
@@ -10,56 +8,25 @@ import { theme, global } from 'src/styles';
 
 import { UserType } from 'src/types';
 
-import { Fetcher } from 'src/utils';
-
-import userAtom from 'src/recoil/user';
-
 import useScrollRestoration from 'src/hooks/scrollResoration';
 
 const queryClient = new QueryClient();
-
-const initState =
-  (user: UserType) =>
-  ({ set }: MutableSnapshot) =>
-    set(userAtom, user);
 
 interface Props extends AppProps {
   user: UserType;
 }
 
-function MyApp({ Component, pageProps, router, user }: Props) {
+function MyApp({ Component, pageProps, router }: Props) {
   useScrollRestoration(router);
   return (
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot initializeState={initState(user)}>
-        <ThemeProvider theme={theme}>
-          <Global styles={global(theme)} />
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Component {...pageProps} />
-          <RegisterModal />
-        </ThemeProvider>
-      </RecoilRoot>
+      <ThemeProvider theme={theme}>
+        <Global styles={global(theme)} />
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Component {...pageProps} />
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }
-
-MyApp.propTypes = {
-  user: PropTypes.objectOf(PropTypes.any),
-};
-
-MyApp.defaultProps = {
-  user: {},
-};
-
-MyApp.getInitialProps = async (context: AppContext) => {
-  const props: { user?: UserType } = {};
-  const token = context.ctx.req?.headers.cookie?.split('=')[1];
-  if (token === undefined) {
-    return props;
-  }
-  const user = await Fetcher.getUsersMe(token);
-  props.user = { ...user, token };
-  return props;
-};
 
 export default MyApp;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -8,11 +8,13 @@ import RegisterModal from 'src/components/modals/RegisterModal';
 
 import { theme, global } from 'src/styles';
 
-import { DashboardUserInfoType, UserType } from 'src/types';
+import { UserType } from 'src/types';
 
 import { Fetcher } from 'src/utils';
 
 import userAtom from 'src/recoil/user';
+
+import useScrollRestoration from 'src/hooks/scrollResoration';
 
 const queryClient = new QueryClient();
 
@@ -25,7 +27,8 @@ interface Props extends AppProps {
   user: UserType;
 }
 
-function MyApp({ user, Component, pageProps }: Props) {
+function MyApp({ Component, pageProps, router, user }: Props) {
+  useScrollRestoration(router);
   return (
     <QueryClientProvider client={queryClient}>
       <RecoilRoot initializeState={initState(user)}>
@@ -49,7 +52,7 @@ MyApp.defaultProps = {
 };
 
 MyApp.getInitialProps = async (context: AppContext) => {
-  const props: { user?: UserType; dashboardUserInfo?: DashboardUserInfoType } = {};
+  const props: { user?: UserType } = {};
   const token = context.ctx.req?.headers.cookie?.split('=')[1];
   if (token === undefined) {
     return props;

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,61 +1,49 @@
-import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import { useInfiniteQuery } from 'react-query';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
 
-import Timeline from 'src/components/Timeline';
 import Header from 'src/components/Header';
-import SigninCard from 'src/components/cards/SigninCard';
-import FloatingButton from 'src/components/buttons/FloatingButton';
-import SuggestionCard from 'src/components/cards/SuggestionCard';
 import HomeHead from 'src/components/heads/HomeHead';
-import { Col } from 'src/components/Grid';
+import HomeMain from 'src/components/mains/HomeMain';
 
-import userAtom, {
-  hasFollowSelector,
-  isAuthenticatedSelector,
-  isRegisteredSelector,
-} from 'src/recoil/user';
-
-import { Page } from 'src/styles';
+import userAtom from 'src/recoil/user';
 
 import { Fetcher } from 'src/utils';
 
-function Home() {
-  const user = useRecoilValue(userAtom);
-  const hasFollow = useRecoilValue(hasFollowSelector);
-  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
-  const isRegistered = useRecoilValue(isRegisteredSelector);
+import { PostType, UserType } from 'src/types';
 
-  const [hasFollowTemp] = useState(hasFollow);
-  const { refetch, data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    ['home', 'posts', user],
-    (context) => Fetcher.getPosts(user, context),
-    {
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-    },
-  );
+interface Props {
+  user: UserType;
+  firstPost?: PostType;
+}
+
+const initState =
+  (user: UserType) =>
+  ({ set }: MutableSnapshot) =>
+    set(userAtom, user);
+
+function Home({ user, firstPost }: Props) {
   return (
     <>
       <HomeHead />
       <Header />
-      <Page.Main>
-        <Col alignItems='center'>
-          {!isAuthenticated && <SigninCard />}
-          {isRegistered && !hasFollowTemp && <SuggestionCard />}
-          {isRegistered && (
-            <Timeline
-              pages={data?.pages}
-              onPostDelete={refetch}
-              onNeedMore={fetchNextPage}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-            />
-          )}
-        </Col>
-      </Page.Main>
-      {isRegistered && <FloatingButton onPostWrite={refetch} />}
+      <RecoilRoot initializeState={initState(user)}>
+        <HomeMain firstPost={firstPost} />
+      </RecoilRoot>
     </>
   );
+}
+
+Home.defaultProps = {
+  firstPost: undefined,
+};
+
+export async function getServerSideProps({ req }: any) {
+  const token = req.headers.cookie?.split('=')[1];
+  if (token === undefined) {
+    return { props: { user: {} } };
+  }
+  const user = await Fetcher.getUsersMe(token);
+  const firstPost = await Fetcher.getFirstPost(user, token);
+  return { props: { user: { ...user, token }, firstPost } };
 }
 
 export default Home;

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -3,6 +3,7 @@ import { MutableSnapshot, RecoilRoot } from 'recoil';
 import Header from 'src/components/Header';
 import HomeHead from 'src/components/heads/HomeHead';
 import HomeMain from 'src/components/mains/HomeMain';
+import RegisterModal from 'src/components/modals/RegisterModal';
 
 import userAtom from 'src/recoil/user';
 
@@ -24,9 +25,10 @@ function Home({ user, firstPost }: Props) {
   return (
     <>
       <HomeHead />
-      <Header />
       <RecoilRoot initializeState={initState(user ?? {})}>
+        <Header />
         <HomeMain firstPost={firstPost} />
+        <RegisterModal />
       </RecoilRoot>
     </>
   );

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -11,7 +11,7 @@ import { Fetcher } from 'src/utils';
 import { PostType, UserType } from 'src/types';
 
 interface Props {
-  user: UserType;
+  user?: UserType;
   firstPost?: PostType;
 }
 
@@ -25,7 +25,7 @@ function Home({ user, firstPost }: Props) {
     <>
       <HomeHead />
       <Header />
-      <RecoilRoot initializeState={initState(user)}>
+      <RecoilRoot initializeState={initState(user ?? {})}>
         <HomeMain firstPost={firstPost} />
       </RecoilRoot>
     </>
@@ -33,17 +33,21 @@ function Home({ user, firstPost }: Props) {
 }
 
 Home.defaultProps = {
+  user: undefined,
   firstPost: undefined,
 };
 
 export async function getServerSideProps({ req }: any) {
+  const props: { user?: UserType; firstPost?: PostType } = {};
   const token = req.headers.cookie?.split('=')[1];
   if (token === undefined) {
-    return { props: { user: {} } };
+    return { props };
   }
   const user = await Fetcher.getUsersMe(token);
   const firstPost = await Fetcher.getFirstPost(user, token);
-  return { props: { user: { ...user, token }, firstPost } };
+  props.user = { ...user, token };
+  props.firstPost = firstPost;
+  return { props };
 }
 
 export default Home;

--- a/frontend/src/pages/posts/[postID].tsx
+++ b/frontend/src/pages/posts/[postID].tsx
@@ -2,6 +2,7 @@ import { MutableSnapshot, RecoilRoot } from 'recoil';
 
 import PostDetail from 'src/components/PostDetail';
 import PostHead from 'src/components/heads/PostHead';
+import RegisterModal from 'src/components/modals/RegisterModal';
 
 import { PostType, UserType } from 'src/types';
 
@@ -27,6 +28,7 @@ function Post({ user, post }: Props) {
       {post && <PostHead postID={_id!} content={content!} image={images![0]?.url} />}
       <RecoilRoot initializeState={initState(user ?? {})}>
         {post && <PostDetail post={post} />}
+        <RegisterModal />
       </RecoilRoot>
     </>
   );

--- a/frontend/src/pages/posts/[postID].tsx
+++ b/frontend/src/pages/posts/[postID].tsx
@@ -24,7 +24,7 @@ function Post({ user, post }: Props) {
 
   return (
     <>
-      <PostHead postID={_id!} content={content!} image={images![0]?.url} />
+      {post && <PostHead postID={_id!} content={content!} image={images![0]?.url} />}
       <RecoilRoot initializeState={initState(user ?? {})}>
         {post && <PostDetail post={post} />}
       </RecoilRoot>
@@ -41,13 +41,12 @@ export async function getServerSideProps({ req, query }: any) {
   const props: { user?: UserType; post?: PostType } = {};
   const { postID } = query;
   const token = req.headers.cookie?.split('=')[1];
-  if (token === undefined) {
-    return { props };
-  }
   const postRequest = Fetcher.getDetailPost(postID);
-  const userRequest = Fetcher.getUsersMe(token);
+  if (token !== undefined) {
+    const userRequest = Fetcher.getUsersMe(token);
+    props.user = { ...(await userRequest), token };
+  }
   props.post = await postRequest;
-  props.user = { ...(await userRequest), token };
   return { props };
 }
 

--- a/frontend/src/pages/random.tsx
+++ b/frontend/src/pages/random.tsx
@@ -3,6 +3,7 @@ import { MutableSnapshot, RecoilRoot } from 'recoil';
 import Header from 'src/components/Header';
 import RandomHead from 'src/components/heads/RandomHead';
 import RandomMain from 'src/components/mains/RandomMain';
+import RegisterModal from 'src/components/modals/RegisterModal';
 
 import userAtom from 'src/recoil/user';
 
@@ -23,9 +24,10 @@ function Random({ user }: Props) {
   return (
     <>
       <RandomHead />
-      <Header />
       <RecoilRoot initializeState={initState(user ?? {})}>
+        <Header />
         <RandomMain />
+        <RegisterModal />
       </RecoilRoot>
     </>
   );

--- a/frontend/src/pages/random.tsx
+++ b/frontend/src/pages/random.tsx
@@ -11,7 +11,7 @@ import { Fetcher } from 'src/utils';
 import { UserType } from 'src/types';
 
 interface Props {
-  user: UserType;
+  user?: UserType;
 }
 
 const initState =
@@ -24,20 +24,25 @@ function Random({ user }: Props) {
     <>
       <RandomHead />
       <Header />
-      <RecoilRoot initializeState={initState(user)}>
+      <RecoilRoot initializeState={initState(user ?? {})}>
         <RandomMain />
       </RecoilRoot>
     </>
   );
 }
 
+Random.defaultProps = {
+  user: undefined,
+};
+
 export async function getServerSideProps({ req }: any) {
+  const props: { user?: UserType } = {};
   const token = req.headers.cookie?.split('=')[1];
   if (token === undefined) {
-    return { props: { user: {} } };
+    return { props };
   }
-  const user = await Fetcher.getUsersMe(token);
-  return { props: { user: { ...user, token } } };
+  props.user = await Fetcher.getUsersMe(token);
+  return { props };
 }
 
 export default Random;

--- a/frontend/src/pages/users/[username].tsx
+++ b/frontend/src/pages/users/[username].tsx
@@ -3,6 +3,7 @@ import { MutableSnapshot, RecoilRoot } from 'recoil';
 import Header from 'src/components/Header';
 import UserMain from 'src/components/mains/UserMain';
 import UserHead from 'src/components/heads/UserHead';
+import RegisterModal from 'src/components/modals/RegisterModal';
 
 import { UserType } from 'src/types';
 
@@ -26,9 +27,10 @@ function User({ user, targetUser }: Props) {
   return (
     <>
       <UserHead username={username} profileImage={profileImage} bio={bio} name={name} />
-      <Header />
       <RecoilRoot initializeState={initState(user ?? {})}>
+        <Header />
         <UserMain targetUser={targetUser ?? {}} />
+        <RegisterModal />
       </RecoilRoot>
     </>
   );

--- a/frontend/src/pages/users/[username].tsx
+++ b/frontend/src/pages/users/[username].tsx
@@ -1,75 +1,56 @@
-import { useInfiniteQuery } from 'react-query';
-import { useRecoilValue } from 'recoil';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
 
 import Header from 'src/components/Header';
-import Timeline from 'src/components/Timeline';
-import UserInfoCard from 'src/components/cards/UserInfoCard';
-import FloatingButton from 'src/components/buttons/FloatingButton';
-import SigninCard from 'src/components/cards/SigninCard';
+import UserMain from 'src/components/mains/UserMain';
 import UserHead from 'src/components/heads/UserHead';
-import UserNotFoundCard from 'src/components/cards/UserNotFoundCard';
-import { Col } from 'src/components/Grid';
 
 import { UserType } from 'src/types';
 
 import { Fetcher } from 'src/utils';
 
-import { isAuthenticatedSelector, isRegisteredSelector } from 'src/recoil/user';
-
-import { Page } from 'src/styles';
+import userAtom from 'src/recoil/user';
 
 interface Props {
-  targetUser: UserType;
+  user?: UserType;
+  targetUser?: UserType;
 }
 
-function User({ targetUser }: Props) {
-  const isAuthenticated = useRecoilValue(isAuthenticatedSelector);
-  const isRegistered = useRecoilValue(isRegisteredSelector);
+const initState =
+  (user: UserType) =>
+  ({ set }: MutableSnapshot) =>
+    set(userAtom, user);
 
-  const isUserExist = Object.keys(targetUser).length !== 0;
-  const { refetch, data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    ['user', 'posts', targetUser],
-    (context) => Fetcher.getUserPosts(targetUser, context),
-    {
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-    },
-  );
-  const { username, profileImage, bio, name } = targetUser;
+function User({ user, targetUser }: Props) {
+  const { username, profileImage, bio, name } = targetUser ?? {};
 
   return (
     <>
       <UserHead username={username} profileImage={profileImage} bio={bio} name={name} />
       <Header />
-      <Page.Main>
-        <Col alignItems='center'>
-          {!isAuthenticated && <SigninCard />}
-          {isUserExist ? (
-            <>
-              <UserInfoCard targetUser={targetUser} />
-              <Timeline
-                pages={data?.pages}
-                onPostDelete={refetch}
-                onNeedMore={fetchNextPage}
-                hasNextPage={hasNextPage}
-                isFetchingNextPage={isFetchingNextPage}
-              />
-            </>
-          ) : (
-            <UserNotFoundCard />
-          )}
-        </Col>
-      </Page.Main>
-      {isRegistered && <FloatingButton onPostWrite={refetch} />}
+      <RecoilRoot initializeState={initState(user ?? {})}>
+        <UserMain targetUser={targetUser ?? {}} />
+      </RecoilRoot>
     </>
   );
 }
 
-export async function getServerSideProps(context: any) {
-  const { username } = context.query;
-  const targetUser = await Fetcher.getUsersByUsername(username);
-  return {
-    props: { targetUser },
-  };
+User.defaultProps = {
+  user: undefined,
+  targetUser: undefined,
+};
+
+export async function getServerSideProps({ query, req }: any) {
+  const props: { user?: UserType; targetUser?: UserType } = {};
+  const { username } = query;
+  const token = req.headers.cookie?.split('=')[1];
+  if (token === undefined) {
+    return props;
+  }
+  const targetUserRequest = Fetcher.getUsersByUsername(username);
+  const userRequest = Fetcher.getUsersMe(token);
+  props.targetUser = await targetUserRequest;
+  props.user = { ...(await userRequest), token };
+  return { props };
 }
 
 export default User;

--- a/frontend/src/pages/users/[username].tsx
+++ b/frontend/src/pages/users/[username].tsx
@@ -42,14 +42,13 @@ User.defaultProps = {
 export async function getServerSideProps({ query, req }: any) {
   const props: { user?: UserType; targetUser?: UserType } = {};
   const { username } = query;
-  const token = req.headers.cookie?.split('=')[1];
-  if (token === undefined) {
-    return props;
-  }
   const targetUserRequest = Fetcher.getUsersByUsername(username);
-  const userRequest = Fetcher.getUsersMe(token);
+  const token = req.headers.cookie?.split('=')[1];
+  if (token !== undefined) {
+    const userRequest = Fetcher.getUsersMe(token);
+    props.user = { ...(await userRequest), token };
+  }
   props.targetUser = await targetUserRequest;
-  props.user = { ...(await userRequest), token };
   return { props };
 }
 

--- a/frontend/src/pages/users/[username]/settings.tsx
+++ b/frontend/src/pages/users/[username]/settings.tsx
@@ -3,6 +3,7 @@ import { MutableSnapshot, RecoilRoot } from 'recoil';
 import Header from 'src/components/Header';
 import SettingsHead from 'src/components/heads/SettingsHead';
 import SettingsMain from 'src/components/mains/SettingsMain';
+import RegisterModal from 'src/components/modals/RegisterModal';
 
 import userAtom from 'src/recoil/user';
 
@@ -23,9 +24,10 @@ function Settings({ user }: Props) {
   return (
     <>
       <SettingsHead />
-      <Header />
       <RecoilRoot initializeState={initState(user ?? {})}>
+        <Header />
         <SettingsMain />
+        <RegisterModal />
       </RecoilRoot>
     </>
   );

--- a/frontend/src/pages/users/[username]/settings.tsx
+++ b/frontend/src/pages/users/[username]/settings.tsx
@@ -1,40 +1,49 @@
-import { useRecoilValue } from 'recoil';
-import { useRouter } from 'next/router';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
 
 import Header from 'src/components/Header';
-import UserSettingsCard from 'src/components/cards/UserSettingsCard';
-import ExternalAuthCard from 'src/components/cards/ExternalAuthCard';
 import SettingsHead from 'src/components/heads/SettingsHead';
-import PermissionDeniedCard from 'src/components/cards/PermissionDeniedCard';
-import { Col } from 'src/components/Grid';
+import SettingsMain from 'src/components/mains/SettingsMain';
 
 import userAtom from 'src/recoil/user';
 
-import { Page } from 'src/styles';
+import { UserType } from 'src/types';
 
-function Settings() {
-  const user = useRecoilValue(userAtom);
-  const router = useRouter();
-  const targetUsername = router.query.username;
+import { Fetcher } from 'src/utils';
 
+const initState =
+  (user: UserType) =>
+  ({ set }: MutableSnapshot) =>
+    set(userAtom, user);
+
+interface Props {
+  user?: UserType;
+}
+
+function Settings({ user }: Props) {
   return (
     <>
       <SettingsHead />
       <Header />
-      <Page.Main>
-        <Col justifyContent='center' alignItems='center'>
-          {targetUsername === user.username ? (
-            <>
-              <UserSettingsCard />
-              <ExternalAuthCard />
-            </>
-          ) : (
-            <PermissionDeniedCard />
-          )}
-        </Col>
-      </Page.Main>
+      <RecoilRoot initializeState={initState(user ?? {})}>
+        <SettingsMain />
+      </RecoilRoot>
     </>
   );
+}
+
+Settings.defaultProps = {
+  user: undefined,
+};
+
+export async function getServerSideProps({ req }: any) {
+  const props: { user?: UserType } = {};
+  const token = req.headers.cookie?.split('=')[1];
+  if (token === undefined) {
+    return props;
+  }
+  const user = await Fetcher.getUsersMe(token);
+  props.user = { ...user, token };
+  return { props };
 }
 
 export default Settings;

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -47,11 +47,15 @@ class Fetcher {
     }
   }
 
-  static async getDashboardUserInfo(username: string): Promise<ReturnType<DashboardUserInfoType>> {
-    const result = await axios.get(`${baseURL}/${version}/users/dashboard`, {
-      params: { username },
-    });
-    return result.data;
+  static async getDashboardUserInfo(username: string): Promise<DashboardUserInfoType> {
+    try {
+      const result = await axios.get(`${baseURL}/${version}/users/dashboard`, {
+        params: { username },
+      });
+      return result.data.data;
+    } catch {
+      return { username: '' };
+    }
   }
 
   static async getFirstPost(user: UserType, token: string): Promise<PostType> {

--- a/frontend/src/utils/Fetcher.ts
+++ b/frontend/src/utils/Fetcher.ts
@@ -54,6 +54,17 @@ class Fetcher {
     return result.data;
   }
 
+  static async getFirstPost(user: UserType, token: string): Promise<PostType> {
+    if (user._id === undefined || !user.isRegistered) {
+      return {};
+    }
+    const result = await axios.get(`${baseURL}/${version}/posts`, {
+      headers: { Authorization: `Bearer ${token}` },
+      params: { user_id: user._id, cursor: 0 },
+    });
+    return result.data.data[0];
+  }
+
   // for client side
   static async getPosts(
     user: UserType,
@@ -64,7 +75,7 @@ class Fetcher {
     }
     const result = await axios.get(`${baseURL}/${version}/posts`, {
       headers: { Authorization: `Bearer ${user.token}` },
-      params: { user_id: user._id, cursor: pageParam ?? 0 },
+      params: { user_id: user._id, cursor: pageParam ?? 1 },
     });
     return result.data;
   }


### PR DESCRIPTION
### 주의
해당 PR은 빌드가 실패합니다.
수정대로 대쉬보드 부분을 건들면 개발에 혼동이 빚어질 것이라 예상되어 가만히 나뒀습니다~

### 한 일
- 홈 타임라인 첫 포스트 ServerSide에서 가져오기
- 스크롤 복원 문제 커스텀 훅으로 해결
- 리코일 루트 전부 페이지 내로 옮기기

### 파일 변경
- frontend/src/components/Timeline/index.tsx: no more data 더 어울리게 변경
- frontend/src/components/mains/HomeMain/index.tsx: 홈 페이지 메인 컴포넌트 분리
- frontend/src/components/mains/RandomMain/index.tsx: 랜덤 페이지 메인 컴포넌트 분리
- frontend/src/components/mains/SettingsMain/index.tsx: 세팅 페이지 메인 컴포넌트 분리
- frontend/src/components/mains/UserMain/index.tsx: 유저 페이지 메인 컴포넌트 분리
- frontend/src/hooks/scrollResoration/index.ts: 스크롤 복원 커스텀 훅 개발👍
- frontend/src/pages/_app.tsx: _app 청소
- frontend/src/pages/home.tsx: 홈 청소 및 `getServerSideProps` 사용
- frontend/src/pages/posts/[postID].tsx: 포스트 청소 및 `getServerSideProps` 사용
- frontend/src/pages/random.tsx: 랜덤 청소 및 `getServerSideProps` 사용
- frontend/src/pages/users/[username].tsx: 유저 청소 및 `getServerSideProps` 사용
- frontend/src/pages/users/[username]/dashboard.tsx: 대쉬보드 청소 및 `getServerSideProps` 사용
- frontend/src/pages/users/[username]/settings.tsx: 세팅 청소 및 `getServerSideProps` 사용
- frontend/src/utils/Fetcher.ts: 포스트 하나만 가져오는 함수 추가 및 리팩토링
