### PR TITLE
children props를 propsWithChildren로 수정

### DIFF
--- a/frontend/src/components/buttons/Common/index.tsx
+++ b/frontend/src/components/buttons/Common/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
 
 import { DEFAULT_BUTTON_MARGIN, DEFAULT_BUTTON_PADDING } from 'src/globals/constants';
@@ -12,7 +12,6 @@ interface Props {
   padding?: number;
   plain?: boolean;
   hidden?: boolean;
-  children: ReactNode;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   clicked?: boolean;
   disabled?: boolean;
@@ -33,7 +32,7 @@ function ButtonCommon({
   disabled,
   red,
   green,
-}: Props) {
+}: PropsWithChildren<Props>) {
   return (
     <Button
       width={width!}

--- a/frontend/src/components/buttons/IconButton/index.tsx
+++ b/frontend/src/components/buttons/IconButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { IconContext } from 'react-icons';
 
@@ -13,7 +13,6 @@ import {
 interface Props {
   width?: number;
   height?: number;
-  children: ReactNode;
   padding?: number;
   margin?: number;
   plain?: boolean;
@@ -36,7 +35,7 @@ function IconButton({
   size,
   clicked,
   disabled,
-}: Props) {
+}: PropsWithChildren<Props>) {
   const props = useMemo(() => ({ size: `${size}` }), [size]);
   return (
     <ButtonCommon

--- a/frontend/src/components/buttons/NavigateIconButton/index.tsx
+++ b/frontend/src/components/buttons/NavigateIconButton/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 
@@ -7,13 +7,12 @@ import { DEFAULT_ICON_SIZE } from 'src/globals/constants';
 
 interface Props {
   href: string;
-  children: ReactNode;
   size?: number;
   plain?: boolean;
   clicked?: boolean;
 }
 
-function NavigateIconButton({ href, children, size, plain, clicked }: Props) {
+function NavigateIconButton({ href, children, size, plain, clicked }: PropsWithChildren<Props>) {
   return (
     <IconButton padding={0} size={size} plain={plain} clicked={clicked!}>
       <Link href={href} passHref>

--- a/frontend/src/components/buttons/socials/Common/index.tsx
+++ b/frontend/src/components/buttons/socials/Common/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
 
 import IconButton from 'src/components/buttons/IconButton';
@@ -6,11 +6,10 @@ import IconButton from 'src/components/buttons/IconButton';
 import { SOCIAL_BUTTON_WIDTH, SOCIAL_BUTTON_HEIGHT, SOCIAL_ICON_SIZE } from 'src/globals/constants';
 
 interface Props {
-  children: ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-function SocialCommon({ children, onClick }: Props) {
+function SocialCommon({ children, onClick }: PropsWithChildren<Props>) {
   return (
     <IconButton
       onClick={onClick}

--- a/frontend/src/components/cards/Common/index.tsx
+++ b/frontend/src/components/cards/Common/index.tsx
@@ -1,15 +1,14 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
 
 import { Wrapper } from './style';
 
 interface Props {
-  children: ReactNode;
   width: number;
   height?: number;
 }
 
-function CardCommon({ children, width, height }: Props) {
+function CardCommon({ children, width, height }: PropsWithChildren<Props>) {
   return (
     <Wrapper width={width} height={height} padding='35px 30px'>
       {children}

--- a/frontend/src/components/inputs/ImageInput/index.tsx
+++ b/frontend/src/components/inputs/ImageInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
 
 import { Uploader } from 'src/utils';
@@ -6,12 +6,11 @@ import { Uploader } from 'src/utils';
 import { Input } from './style';
 
 interface Props {
-  children: ReactNode;
   // eslint-disable-next-line no-unused-vars
   onImageUpload: (image: string) => void;
 }
 
-function ImageInput({ onImageUpload, children }: Props) {
+function ImageInput({ onImageUpload, children }: PropsWithChildren<Props>) {
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files!);
     // eslint-disable-next-line no-param-reassign

--- a/frontend/src/components/modals/Common/index.tsx
+++ b/frontend/src/components/modals/Common/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
 
 import ButtonCommon from 'src/components/buttons/Common';
@@ -9,7 +9,6 @@ import { DEFAULT_MODAL_WIDTH } from 'src/globals/constants';
 import { Background, Card, Title } from './style';
 
 interface Props {
-  children?: ReactNode;
   onClose?: VoidFunction;
   onConfirm?: VoidFunction;
   close?: string;
@@ -30,7 +29,7 @@ function ModalCommon({
   width,
   disabled,
   title,
-}: Props) {
+}: PropsWithChildren<Props>) {
   return (
     <>
       <Background onClick={onClose} />

--- a/frontend/src/components/modals/HeaderModal/index.tsx
+++ b/frontend/src/components/modals/HeaderModal/index.tsx
@@ -1,15 +1,14 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 
 import PropTypes from 'prop-types';
 import { Wrapper } from './style';
 
 interface Props {
-  children: ReactNode;
   right?: boolean;
   width?: number;
 }
 
-function HeaderModal({ children, right, width }: Props) {
+function HeaderModal({ children, right, width }: PropsWithChildren<Props>) {
   return (
     <Wrapper right={right!} width={width!}>
       {children}


### PR DESCRIPTION
### 제목
children props를 propsWithChildren로 수정

### 파일 변경
- frontend/src/components/buttons/Common/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/buttons/IconButton/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/buttons/NavigateIconButton/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/buttons/NavigateIconButton/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/cards/Common/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/inputs/ImageInput/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/modals/Common/index.tsx : children props를 propsWithChildren으로 변경
- frontend/src/components/modals/HeaderModal/index.tsx : children props를 propsWithChildren으로 변경